### PR TITLE
Fix: Do not crash when deleting a coaster from the world.

### DIFF
--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -587,6 +587,7 @@ uint8 CoasterInstance::GetEntranceDirections(const XYZPoint16 &vox) const
 RideEntryResult CoasterInstance::EnterRide(int guest, TileEdge edge)
 {
 	return RER_REFUSED; /// \todo Store the guest number.
+	/** \todo Implement RemoveAllPeople when allowing people on the ride. */
 }
 
 XYZPoint32 CoasterInstance::GetExit(int guest, TileEdge entry_edge)
@@ -596,7 +597,7 @@ XYZPoint32 CoasterInstance::GetExit(int guest, TileEdge entry_edge)
 
 void CoasterInstance::RemoveAllPeople()
 {
-	assert(false); // Not yet implemented.
+	/** \todo Implement when allowing people on the ride. */
 }
 
 /**


### PR DESCRIPTION
Coasters cannot have people yet, it's wrong to crash on something that cannot cause problems :p
