### PR TITLE
Rework fence storage

### DIFF
--- a/doc/savegame.rst
+++ b/doc/savegame.rst
@@ -220,6 +220,7 @@ Version history
 
 - 1 (20140419) Initial version.
 - 2 (20150410) Added fence data.
+- 3 (20150428) Fences near the lowest corner of a steep slope moved from top voxel to base voxel.
 
 
 .. vim: spell

--- a/src/fence.h
+++ b/src/fence.h
@@ -41,4 +41,7 @@ enum FenceType {
 /* 4 bits are used to store FenceType in the map array. */
 assert_compile(FENCE_TYPE_COUNT <= FENCE_TYPE_INVALID);
 
+/** %Fence data with #FENCE_TYPE_INVALID at all four edges. */
+static const uint16 ALL_INVALID_FENCES = FENCE_TYPE_INVALID | (FENCE_TYPE_INVALID << 4) | (FENCE_TYPE_INVALID << 8) | (FENCE_TYPE_INVALID << 12);
+
 #endif

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -46,7 +46,7 @@ static inline void CopyVoxel(Voxel *dest, Voxel *src, bool copy_voxel_objects)
 	dest->instance = src->instance;
 	dest->instance_data = src->instance_data;
 	dest->ground = src->ground;
-	dest->fence = src->fence;
+	dest->fences = src->fences;
 	if (copy_voxel_objects) CopyVoxelObjectList(dest, src);
 }
 
@@ -65,6 +65,16 @@ static void CopyStackData(Voxel *dest, Voxel *src, int count, bool copy_voxel_ob
 		src++;
 		count--;
 	}
+}
+
+/** Make the voxel empty. */
+void Voxel::ClearVoxel()
+{
+	this->SetGroundType(GTP_INVALID);
+	this->SetFoundationType(FDT_INVALID);
+	this->SetGrowth(0);
+	this->SetFences(ALL_INVALID_FENCES);
+	this->ClearInstances();
 }
 
 /**
@@ -87,7 +97,7 @@ void Voxel::Load(Loader &ldr, uint32 version)
 			ldr.SetFailMessage("Unknown voxel instance data");
 		}
 
-		if (version == 2) this->fence = ldr.GetWord();
+		if (version == 2) this->fences = ldr.GetWord();
 	} else {
 		ldr.SetFailMessage("Unknown voxel version");
 	}
@@ -106,7 +116,7 @@ void Voxel::Save(Saver &svr) const
 	} else {
 		svr.PutByte(SRI_FREE); // Full rides save their own data from the world.
 	}
-	svr.PutWord(this->fence);
+	svr.PutWord(this->fences);
 }
 
 /**

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -518,28 +518,27 @@ TileOwner VoxelWorld::GetTileOwner(uint16 x, uint16 y)
  * The following functions interact with the map.
  * - #GetGroundFencesFromMap gets the fences at ground level from a voxel stack.
  * - #AddGroundFencesToMap sets the fences to a voxel stack.
- *
  */
 static const uint16 _fences_mask_at_base[] = {
-	0xFFFF, // Imploded ground slope  0
-	0xFFFF, // Imploded ground slope  1
-	0xFFFF, // Imploded ground slope  2
-	0xFFF0, // Imploded ground slope  3
-	0xFFFF, // Imploded ground slope  4
-	0xFFFF, // Imploded ground slope  5
-	0xFF0F, // Imploded ground slope  6
-	0xFF00, // Imploded ground slope  7
-	0xFFFF, // Imploded ground slope  8
-	0x0FFF, // Imploded ground slope  9
-	0xFFFF, // Imploded ground slope 10
-	0x0FF0, // Imploded ground slope 11
-	0xF0FF, // Imploded ground slope 12
-	0x00FF, // Imploded ground slope 13
-	0xF00F, // Imploded ground slope 14
-	0x0FF0, // Imploded ground slope 15 (base steep north)
-	0xFF00, // Imploded ground slope 16 (base steep east)
-	0xF00F, // Imploded ground slope 17 (base steep south)
-	0x00FF, // Imploded ground slope 18 (base steep west)
+	0xFFFF, // ISL_FLAT
+	0xFFFF, // ISL_NORTH
+	0xFFFF, // ISL_EAST
+	0xFFF0, // ISL_NORTH_EAST
+	0xFFFF, // ISL_SOUTH
+	0xFFFF, // ISL_NORTH_SOUTH
+	0xFF0F, // ISL_EAST_SOUTH
+	0xFF00, // ISL_NORTH_EAST_SOUTH
+	0xFFFF, // ISL_WEST
+	0x0FFF, // ISL_NORTH_WEST
+	0xFFFF, // ISL_EAST_WEST
+	0x0FF0, // ISL_NORTH_EAST_WEST
+	0xF0FF, // ISL_SOUTH_WEST
+	0x00FF, // ISL_NORTH_SOUTH_WEST
+	0xF00F, // ISL_EAST_SOUTH_WEST
+	0x0FF0, // ISL_BOTTOM_STEEP_NORTH
+	0xFF00, // ISL_BOTTOM_STEEP_EAST
+	0xF00F, // ISL_BOTTOM_STEEP_SOUTH
+	0x00FF, // ISL_BOTTOM_STEEP_WEST
 };
 
 /**

--- a/src/map.h
+++ b/src/map.h
@@ -137,9 +137,9 @@ public:
 	 * Set all the fences of the voxel.
 	 * @param fences Type of the fences at each edge.
 	 */
-	inline uint16 SetFences(uint16 fences)
+	inline void SetFences(uint16 fences)
 	{
-		return this->fences = fences;
+		this->fences = fences;
 	}
 
 	/**

--- a/src/map.h
+++ b/src/map.h
@@ -114,7 +114,33 @@ public:
 		this->instance_data = instance_data;
 	}
 
-	uint16 fence; ///< 4 bits used for each edge. EDGE_NE..EDGE_NW. Gives the fence type or FENCE_TYPE_INVALID if the voxel has no fence for this edge.
+	/**
+	 * Fences of the voxel. @see FenceType
+	 * - bit  0.. 3: Fence type of the NE edge.
+	 * - bit  4.. 7: Fence type of the SE edge.
+	 * - bit  8..11: Fence type of the SW edge.
+	 * - bit 12..15: Fence type of the NW edge.
+	 */
+	uint16 fences;
+
+	/**
+	 * Get the fences of the voxel. Use #GetFenceType and #SetFenceType for further manipulation
+	 * of the fence data.
+	 * @return Type of the fences at each edge.
+	 */
+	inline uint16 GetFences() const
+	{
+		return this->fences;
+	}
+
+	/**
+	 * Set all the fences of the voxel.
+	 * @param fences Type of the fences at each edge.
+	 */
+	inline uint16 SetFences(uint16 fences)
+	{
+		return this->fences = fences;
+	}
 
 	/**
 	 * Set the fence type of one of the four edges.
@@ -127,7 +153,7 @@ public:
 	 */
 	inline FenceType GetFenceType(TileEdge edge) const
 	{
-		return (FenceType)GB(this->fence, (edge & 3) * 4, 4);
+		return (FenceType)GB(this->fences, (edge & 3) * 4, 4);
 	}
 
 	/**
@@ -142,7 +168,7 @@ public:
 	inline void SetFenceType(TileEdge edge, FenceType fence_type)
 	{
 		assert(fence_type < FENCE_TYPE_COUNT || fence_type == FENCE_TYPE_INVALID);
-		SB(this->fence, (edge & 3) * 4, 4, fence_type & 0xF);
+		SB(this->fences, (edge & 3) * 4, 4, fence_type & 0xF);
 	}
 
 	/**
@@ -276,18 +302,6 @@ public:
 		return this->GetInstance() == SRI_FREE && this->GetGroundType() == GTP_INVALID && this->GetFoundationType() == FDT_INVALID;
 	}
 
-	/** Make the voxel empty. */
-	void ClearVoxel()
-	{
-		this->SetGroundType(GTP_INVALID);
-		this->SetFoundationType(FDT_INVALID);
-		this->SetGrowth(0);
-		for (TileEdge i = EDGE_BEGIN; i < EDGE_COUNT; i++) {
-			this->SetFenceType(i, FENCE_TYPE_INVALID);
-		}
-		this->ClearInstances();
-	}
-
 	VoxelObject *voxel_objects; ///< First voxel object in this voxel.
 
 	/**
@@ -299,6 +313,7 @@ public:
 		return this->voxel_objects != nullptr;
 	}
 
+	void ClearVoxel();
 	void Save(Saver &svr) const;
 	void Load(Loader &ldr, uint32 version);
 };
@@ -438,6 +453,29 @@ static inline PathType GetPathType(uint16 instance_data)
 static inline uint16 MakePathInstanceData(uint8 slope, PathType path_type)
 {
 	return slope | (path_type << 6);
+}
+
+/**
+ * Get the fence type of one of the four edges.
+ * @param fences Fences data of the voxel.
+ * @param edge The edge to retrieve.
+ * @return The fence type or #FENCE_TYPE_INVALID if the edge has no fence.
+ */
+inline FenceType GetFenceType(uint16 fences, TileEdge edge)
+{
+	return static_cast<FenceType>(GB(fences, edge * 4, 4));
+}
+
+/**
+ * Set the fence type of one of the four edges.
+ * @param fences Fences data of the voxel.
+ * @param edge The edge to set.
+ * @param ftype Type of fence to set at the given edge.
+ * @return The updated fences data.
+ */
+inline uint16 SetFenceType(uint16 fences, TileEdge edge, FenceType ftype)
+{
+	return SB(fences, edge * 4, 4, ftype);
 }
 
 /** Possible ownerships of a tile. */

--- a/src/map.h
+++ b/src/map.h
@@ -143,35 +143,6 @@ public:
 	}
 
 	/**
-	 * Set the fence type of one of the four edges.
-	 * @param edge The edge to modify EDGE_NE..EDGE_NW
-	 * @return The fence type or FENCE_TYPE_INVALID if the edge has no fence
-	 * @note For steep slope all fences are stored in the top voxel. For non-steep
-	 * slope that have both corners raised, the fence type is stored in the voxel
-	 * above. This method will get what is stored in this voxel. You need to make
-	 * sure to call this method for the right voxel in the voxel stack.
-	 */
-	inline FenceType GetFenceType(TileEdge edge) const
-	{
-		return (FenceType)GB(this->fences, (edge & 3) * 4, 4);
-	}
-
-	/**
-	 * Set the fence type of one of the four edges.
-	 * @param edge The edge to modify EDGE_NE..EDGE_NW
-	 * @param fence_type The fence type to use or FENCE_TYPE_INVALID to disable fence of this edge
-	 * @note For steep slope all fences should be stored in the top voxel. For non-steep
-	 * slope that have both corners raised, the fence type should be stored in the voxel
-	 * above. This method will set the fence type of the given voxel. You need to make
-	 * sure to call this method for the right voxel in the voxel stack.
-	 */
-	inline void SetFenceType(TileEdge edge, FenceType fence_type)
-	{
-		assert(fence_type < FENCE_TYPE_COUNT || fence_type == FENCE_TYPE_INVALID);
-		SB(this->fences, (edge & 3) * 4, 4, fence_type & 0xF);
-	}
-
-	/**
 	 * Ground and foundations.
 	 * - bit  0.. 3 (4): Type of foundation. @see FoundationType
 	 * - bit  4.. 7 (4): Ground type. @see GroundType

--- a/src/map.h
+++ b/src/map.h
@@ -660,6 +660,12 @@ protected:
 	VoxelStackMap modified_stacks; ///< Modified voxel stacks.
 };
 
+uint16 MergeGroundFencesAtBase(uint16 vxbase_fences, uint16 fences, uint8 base_tile_slope);
+bool HasTopVoxelFences(uint8 base_tile_slope);
+uint16 MergeGroundFencesAtTop(uint16 vxtop_fences, uint16 fences, uint8 base_tile_slope);
+void AddGroundFencesToMap(uint16 fences, VoxelStack *stack, int base_z);
+uint16 GetGroundFencesFromMap(const VoxelStack *stack, int base_z);
+
 extern VoxelWorld _world;
 extern WorldAdditions _additions;
 

--- a/src/sprite_store.h
+++ b/src/sprite_store.h
@@ -491,15 +491,16 @@ public:
 	 * Get a fence sprite.
 	 * @param type FenceType of fence.
 	 * @param edge The edge of the voxel.
-	 * @param slope The exploded slope of the voxel.
+	 * @param tslope The imploded slope of the voxel.
 	 * @param orient Orientation.
 	 * @return Requested sprite if available.
 	 */
-	const ImageData *GetFenceSprite(FenceType type, TileEdge edge, TileSlope slope, ViewOrientation orient) const
+	const ImageData *GetFenceSprite(FenceType type, TileEdge edge, uint8 tslope, ViewOrientation orient) const
 	{
 		if (this->fence[type] == nullptr) return nullptr;
 
 		uint8 corner_height[4];
+		TileSlope slope = ExpandTileSlope(tslope);
 		ComputeCornerHeight(slope, (slope & TSB_TOP) != 0 ? 1 : 0, corner_height);
 
 		/*

--- a/src/terraform.h
+++ b/src/terraform.h
@@ -32,7 +32,7 @@ struct GroundData {
  * Map of voxels to ground modification data.
  * @ingroup map_group
  */
-typedef std::map<Point32, GroundData> GroundModificationMap;
+typedef std::map<Point16, GroundData> GroundModificationMap;
 
 /**
  * Store and manage terrain changes.
@@ -41,22 +41,22 @@ typedef std::map<Point32, GroundData> GroundModificationMap;
  */
 class TerrainChanges {
 public:
-	TerrainChanges(const Point32 &base, uint16 xsize, uint16 ysize);
+	TerrainChanges(const Point16 &base, uint16 xsize, uint16 ysize);
 	~TerrainChanges();
 
-	void UpdatelevellingHeight(const Point32 &pos, int direction, uint8 *height);
-	bool ChangeVoxel(const Point32 &pos, uint8 height, int direction);
-	bool ChangeCorner(const Point32 &pos, TileCorner corner, int direction);
+	void UpdatelevellingHeight(const Point16 &pos, int direction, uint8 *height);
+	bool ChangeVoxel(const Point16 &pos, uint8 height, int direction);
+	bool ChangeCorner(const Point16 &pos, TileCorner corner, int direction);
 	bool ModifyWorld(int direction);
 
 	GroundModificationMap changes; ///< Registered changes.
 
 private:
-	Point32 base; ///< Base position of the smooth changing world.
+	Point16 base; ///< Base position of the smooth changing world.
 	uint16 xsize; ///< Horizontal size of the smooth changing world.
 	uint16 ysize; ///< Vertical size of the smooth changing world.
 
-	GroundData *GetGroundData(const Point32 &pos);
+	GroundData *GetGroundData(const Point16 &pos);
 };
 
 /** State of the terraform coordinator. */

--- a/src/tile.h
+++ b/src/tile.h
@@ -72,6 +72,8 @@ enum TileSlope {
 	TSB_SOUTHEAST = TSB_SOUTH | TSB_EAST, ///< Both south and east corners are raised.
 	TSB_SOUTHWEST = TSB_SOUTH | TSB_WEST, ///< Both south and west corners are raised.
 
+	TS_TOP_OFFSET = 4, ///< Offset of imploded steep top-slopes relative to their base slope.
+
 };
 DECLARE_ENUM_AS_BIT_SET(TileSlope)
 
@@ -144,7 +146,7 @@ static inline bool IsImplodedSteepSlope(uint8 ts)
  */
 static inline bool IsImplodedSteepSlopeTop(uint8 ts)
 {
-	return ts >= 19;
+	return ts >= 15 + TS_TOP_OFFSET;
 }
 
 /**
@@ -240,8 +242,6 @@ extern const Point16 _exit_dxy[EDGE_COUNT];
 
 void ComputeCornerHeight(TileSlope slope, uint8 base_height, uint8 *output);
 void ComputeSlopeAndHeight(uint8 *corners, TileSlope *slope, uint8 *base);
-bool MayHaveGroundFenceInVoxelAbove(TileSlope slope);
-bool StoreFenceInUpperVoxel(TileSlope slope, TileEdge edge);
 TileEdge GetAdjacentEdge(int x1, int y1, int x2, int y2);
 
 #endif

--- a/src/tile.h
+++ b/src/tile.h
@@ -77,7 +77,36 @@ enum TileSlope {
 };
 DECLARE_ENUM_AS_BIT_SET(TileSlope)
 
-static const uint8 NUM_SLOPE_SPRITES = 15 + 4 + 4; ///< Number of sprites for defining a surface tile.
+/** Tile slopes in imploded (sprite) order. */
+enum ImplodedSlopes {
+	ISL_FLAT,               ///< Flat surface tile.
+	ISL_NORTH,              ///< North corner up.
+	ISL_EAST,               ///< East corner up.
+	ISL_NORTH_EAST,         ///< North, east corners up.
+	ISL_SOUTH,              ///< South corner up.
+	ISL_NORTH_SOUTH,        ///< North, south corners up.
+	ISL_EAST_SOUTH,         ///< East, south corners up.
+	ISL_NORTH_EAST_SOUTH,   ///< North, east, south corners up.
+	ISL_WEST,               ///< West corner up.
+	ISL_NORTH_WEST,         ///< West, north corners up.
+	ISL_EAST_WEST,          ///< West, east corners up.
+	ISL_NORTH_EAST_WEST,    ///< West, north, east corners up.
+	ISL_SOUTH_WEST,         ///< West, south corners up.
+	ISL_NORTH_SOUTH_WEST,   ///< West, north, south corners up.
+	ISL_EAST_SOUTH_WEST,    ///< West, east, south corners up.
+
+	ISL_BOTTOM_STEEP_NORTH, ///< Steep slope, north top (bottom part).
+	ISL_BOTTOM_STEEP_EAST,  ///< Steep slope, east  top (bottom part).
+	ISL_BOTTOM_STEEP_SOUTH, ///< Steep slope, south top (bottom part).
+	ISL_BOTTOM_STEEP_WEST,  ///< Steep slope, west  top (bottom part).
+
+	ISL_TOP_STEEP_NORTH,    ///< Steep slope, north top (top part).
+	ISL_TOP_STEEP_EAST,     ///< Steep slope, east  top (top part).
+	ISL_TOP_STEEP_SOUTH,    ///< Steep slope, south top (top part).
+	ISL_TOP_STEEP_WEST,     ///< Steep slope, west  top (top part).
+
+	NUM_SLOPE_SPRITES = 15 + 4 + 4, ///< Number of sprites for defining a surface tile.
+};
 
 /** Sprites for supports available for use. */
 enum SupportSprites {
@@ -136,7 +165,7 @@ DECLARE_POSTFIX_INCREMENT(TileEdge)
  */
 static inline bool IsImplodedSteepSlope(uint8 ts)
 {
-	return ts >= 15;
+	return ts >= ISL_BOTTOM_STEEP_NORTH;
 }
 
 /**
@@ -146,7 +175,7 @@ static inline bool IsImplodedSteepSlope(uint8 ts)
  */
 static inline bool IsImplodedSteepSlopeTop(uint8 ts)
 {
-	return ts >= 15 + TS_TOP_OFFSET;
+	return ts >= ISL_TOP_STEEP_NORTH;
 }
 
 /**
@@ -157,9 +186,9 @@ static inline bool IsImplodedSteepSlopeTop(uint8 ts)
  */
 static inline TileSlope ExpandTileSlope(uint8 v)
 {
-	if (v < 15) return (TileSlope)v;
-	if (v < 19) return TSB_STEEP | (TileSlope)(1 << (v - 15));
-	return TSB_STEEP | TSB_TOP | (TileSlope)(1 << (v - 19));
+	if (v < ISL_BOTTOM_STEEP_NORTH) return static_cast<TileSlope>(v);
+	if (v < ISL_TOP_STEEP_NORTH) return static_cast<TileSlope>(TSB_STEEP | (1 << (v - ISL_BOTTOM_STEEP_NORTH)));
+	return static_cast<TileSlope>(TSB_STEEP | TSB_TOP | (1 << (v - ISL_TOP_STEEP_NORTH)));
 }
 
 /**
@@ -172,7 +201,7 @@ static inline uint8 ImplodeTileSlope(TileSlope s)
 {
 	if ((s & TSB_STEEP) == 0) return s;
 
-	uint8 base = ((s & TSB_TOP) == 0) ? 15 : 19;
+	uint8 base = ((s & TSB_TOP) == 0) ? ISL_BOTTOM_STEEP_NORTH : ISL_TOP_STEEP_NORTH;
 	if ((s & TSB_NORTH) != 0) return base;
 	if ((s & TSB_EAST)  != 0) return base + 1;
 	if ((s & TSB_SOUTH) != 0) return base + 2;

--- a/src/tile_func.cpp
+++ b/src/tile_func.cpp
@@ -103,36 +103,6 @@ void ComputeSlopeAndHeight(uint8 *corners, TileSlope *slope, uint8 *base)
 }
 
 /**
- * For some ground slopes, the fence type is stored in the voxel above.
- * Check if this is the case for a voxel with the given exploded slope.
- * @param slope Exploded slope
- * @return true if one or more edges of a voxel with given slope will have the fence stored in the voxel above.
- */
-bool MayHaveGroundFenceInVoxelAbove(TileSlope slope)
-{
-	if ((slope & TSB_STEEP) != 0) return true;
-	for (uint8 i = 0; i < 4; i++) {
-		/* Are there two adjacent corners that are raised? */
-		if ((slope & (1 << i)) != 0 && (slope & (1 << ((i + 1) % 4))) != 0) return true;
-	}
-	return false;
-}
-
-/**
- * For some ground slopes, the fence type is stored in the voxel above.
- * Check if this is the case for given edge of a voxel with the given slope.
- * @param slope Exploded slope.
- * @param edge Edge to inspect.
- * @return true if one or more edges of a voxel with given slope will have the fence stored in the voxel above.
- */
-bool StoreFenceInUpperVoxel(TileSlope slope, TileEdge edge)
-{
-	if ((slope & TSB_STEEP) != 0) return true;
-	/* Are both edge corners raised? */
-	return (slope & (1 << edge)) != 0 && (slope & (1 << ((edge + 1) % 4))) != 0;
-}
-
-/**
  * Find the outgoing edge of tile \a x1, \a y1) to arrive at adjacent tile (\a x2, \a y2).
  * @param x1 X coordinate first tile.
  * @param y1 Y coordinate first tile.

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -996,8 +996,9 @@ void SpriteCollector::CollectVoxel(const Voxel *voxel, const XYZPoint16 &voxel_p
 	}
 
 	/* Fences */
+	uint16 fences = voxel->GetFences();
 	for (TileEdge edge = EDGE_BEGIN; edge < EDGE_COUNT; edge++) {
-		FenceType fence_type = voxel->GetFenceType(edge);
+		FenceType fence_type = GetFenceType(fences, edge);
 		if (fence_type != FENCE_TYPE_INVALID) {
 			DrawData dd;
 			dd.level = slice;

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -271,7 +271,7 @@ protected:
 	void CollectVoxel(const Voxel *vx, const XYZPoint16 &voxel_pos, int32 xnorth, int32 ynorth) override;
 	void SetupSupports(const VoxelStack *stack, uint xpos, uint ypos) override;
 	CursorType GetCursorType(const XYZPoint16 &voxel_pos);
-	const ImageData *GetCursorSpriteAtPos(const XYZPoint16 &voxel_pos, uint8 tslope, uint8 &yoffset);
+	const ImageData *GetCursorSpriteAtPos(const XYZPoint16 &voxel_pos, uint8 tslope);
 
 	/** For each orientation the location of the real northern corner of a tile relative to the northern displayed corner. */
 	Point16 north_offsets[4];
@@ -763,12 +763,10 @@ CursorType SpriteCollector::GetCursorType(const XYZPoint16 &voxel_pos)
  * Get the cursor sprite at a given voxel.
  * @param voxel_pos Position of the voxel being drawn.
  * @param tslope Slope of the tile.
- * @param yoffset Offset in screen y coordinates for where to render the sprite related to given voxel.
  * @return Pointer to the cursor sprite, or \c nullptr if no cursor available.
  */
-const ImageData *SpriteCollector::GetCursorSpriteAtPos(const XYZPoint16 &voxel_pos, uint8 tslope, uint8 &yoffset)
+const ImageData *SpriteCollector::GetCursorSpriteAtPos(const XYZPoint16 &voxel_pos, uint8 tslope)
 {
-	yoffset = 0;
 	CursorType ctype = this->GetCursorType(voxel_pos);
 	switch (ctype) {
 		case CUR_TYPE_NORTH:
@@ -899,8 +897,7 @@ void SpriteCollector::CollectVoxel(const Voxel *voxel, const XYZPoint16 &voxel_p
 		CursorType ctype = this->GetCursorType(voxel_pos);
 		if (ctype == CUR_TYPE_INVALID) return;
 
-		uint8 cursor_yoffset = 0;
-		const ImageData *mspr = this->GetCursorSpriteAtPos(voxel_pos, SL_FLAT, cursor_yoffset);
+		const ImageData *mspr = this->GetCursorSpriteAtPos(voxel_pos, SL_FLAT);
 		if (mspr != nullptr) {
 			DrawData dd;
 			dd.level = slice;
@@ -908,7 +905,7 @@ void SpriteCollector::CollectVoxel(const Voxel *voxel, const XYZPoint16 &voxel_p
 			dd.order = SO_CURSOR;
 			dd.sprite = mspr;
 			dd.base.x = this->xoffset + xnorth - this->rect.base.x;
-			dd.base.y = this->yoffset + ynorth - this->rect.base.y + cursor_yoffset;
+			dd.base.y = this->yoffset + ynorth - this->rect.base.y;
 			dd.recolour = nullptr;
 			this->draw_images.insert(dd);
 		}
@@ -1044,8 +1041,7 @@ void SpriteCollector::CollectVoxel(const Voxel *voxel, const XYZPoint16 &voxel_p
 	/* Sprite cursor (arrow) */
 	CursorType ctype = this->GetCursorType(voxel_pos);
 	if (ctype != CUR_TYPE_INVALID) {
-		uint8 cursor_yoffset = 0;
-		const ImageData *mspr = this->GetCursorSpriteAtPos(voxel_pos, gslope, cursor_yoffset);
+		const ImageData *mspr = this->GetCursorSpriteAtPos(voxel_pos, gslope);
 		if (mspr != nullptr) {
 			DrawData dd;
 			dd.level = slice;
@@ -1054,7 +1050,7 @@ void SpriteCollector::CollectVoxel(const Voxel *voxel, const XYZPoint16 &voxel_p
 			dd.order = SO_CURSOR;
 			dd.sprite = mspr;
 			dd.base.x = this->xoffset + xnorth - this->rect.base.x;
-			dd.base.y = this->yoffset + ynorth - this->rect.base.y + cursor_yoffset;
+			dd.base.y = this->yoffset + ynorth - this->rect.base.y;
 			dd.recolour = nullptr;
 			this->draw_images.insert(dd);
 		}

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -556,7 +556,7 @@ void MultiCursor::ClearZPositions()
  * Reset the cached height of a voxel in the area.
  * @param pos Position to reset (may be outside the cursor).
  */
-void MultiCursor::ResetZPosition(const Point32 &pos)
+void MultiCursor::ResetZPosition(const Point16 &pos)
 {
 	if (this->rect.IsPointInside(pos)) {
 		this->zpos[pos.x - this->rect.base.x][pos.y - this->rect.base.y] = -1;
@@ -598,7 +598,7 @@ CursorType MultiCursor::GetCursor(const XYZPoint16 &cursor_pos)
 {
 	if (this->type == CUR_TYPE_INVALID) return CUR_TYPE_INVALID;
 
-	Point32 pt(cursor_pos.x, cursor_pos.y);
+	Point16 pt(cursor_pos.x, cursor_pos.y);
 	if (!this->rect.IsPointInside(pt)) return CUR_TYPE_INVALID;
 	if (cursor_pos.z != this->GetZpos(cursor_pos.x, cursor_pos.y)) return CUR_TYPE_INVALID;
 	return CUR_TYPE_TILE;
@@ -608,7 +608,7 @@ uint8 MultiCursor::GetMaxCursorHeight(uint16 xpos, uint16 ypos, uint8 zpos)
 {
 	if (this->type == CUR_TYPE_INVALID) return zpos;
 
-	Point32 pt(xpos, ypos);
+	Point16 pt(xpos, ypos);
 	if (!this->rect.IsPointInside(pt)) return zpos;
 	return std::max(zpos, this->GetZpos(xpos, ypos));
 }
@@ -621,7 +621,7 @@ uint8 MultiCursor::GetMaxCursorHeight(uint16 xpos, uint16 ypos, uint8 zpos)
  * @return Whether the function has set the cursor.
  * @note The \a rect should be non-empty, and less than 10x10 tiles.
  */
-bool MultiCursor::SetCursor(const Rectangle32 &rect, CursorType type, bool always)
+bool MultiCursor::SetCursor(const Rectangle16 &rect, CursorType type, bool always)
 {
 	if (type == CUR_TYPE_INVALID) {
 		if (!always && this->type == CUR_TYPE_INVALID) return false;
@@ -632,7 +632,7 @@ bool MultiCursor::SetCursor(const Rectangle32 &rect, CursorType type, bool alway
 	assert(type == CUR_TYPE_TILE);
 
 	/* Copy and sanitize cursor. */
-	Rectangle32 r(rect);
+	Rectangle16 r(rect);
 	r.RestrictTo(0, 0, static_cast<int>(_world.GetXSize()), static_cast<int>(_world.GetYSize()));
 	if (r.width > 10) r.width = 10;
 	if (r.height > 10) r.height = 10;

--- a/src/viewport.h
+++ b/src/viewport.h
@@ -198,10 +198,8 @@ public:
 	EdgeCursor(Viewport *vp);
 
 	XYZPoint16 cursor_pos; ///< %Voxel position of the cursor.
-	const ImageData *sprite; ///< Cursor sprite.
-	uint8 yoffset; ///< Y offset for where to render the sprite on the screen.
 
-	bool SetCursor(const XYZPoint16 &cursor_pos, CursorType type, const ImageData *sprite, uint8 yoffset, bool always = false);
+	bool SetCursor(const XYZPoint16 &cursor_pos, CursorType type, bool always = false);
 
 	void MarkDirty() override;
 	CursorType GetCursor(const XYZPoint16 &cursor_pos) override;

--- a/src/viewport.h
+++ b/src/viewport.h
@@ -175,10 +175,10 @@ class MultiCursor : public BaseCursor {
 public:
 	MultiCursor(Viewport *vp);
 
-	Rectangle32 rect;   ///< Rectangle with cursors.
+	Rectangle16 rect;   ///< Rectangle with cursors.
 	int16 zpos[10][10]; ///< Cached Z positions of the cursors (negative means not set).
 
-	bool SetCursor(const Rectangle32 &rect, CursorType type, bool always = false);
+	bool SetCursor(const Rectangle16 &rect, CursorType type, bool always = false);
 
 	void MarkDirty() override;
 	CursorType GetCursor(const XYZPoint16 &cursor_pos) override;
@@ -186,7 +186,7 @@ public:
 
 	void ClearZPositions();
 	uint8 GetZpos(int xpos, int ypos);
-	void ResetZPosition(const Point32 &pos);
+	void ResetZPosition(const Point16 &pos);
 };
 
 /**


### PR DESCRIPTION
Fences did all kinds of dirty tricks to get sprites, positions, and voxels right. Cleaned it all up.

Only remaining problem is that the EdgeCursor cannot display a fence at a raised edge of a non-steep tile due to not having the slope below available. That will however become a complete non-issue by reworking the mouse modes.
