### PR TITLE
Codechange: Move include <string> to the global stdafx.h file. Fixes #109

### DIFF
--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -11,7 +11,6 @@
 #include "config_reader.h"
 #include "fileio.h"
 #include "string_func.h"
-#include <string>
 
 /**
  * Construct a key/value item.

--- a/src/rcdfile.h
+++ b/src/rcdfile.h
@@ -10,7 +10,6 @@
 #ifndef RCDFILE_H
 #define RCDFILE_H
 
-#include <string>
 #include <map>
 
 /** Information about an RCD file. */

--- a/src/rcdgen/check_data.cpp
+++ b/src/rcdgen/check_data.cpp
@@ -11,7 +11,6 @@
 #include <map>
 #include <vector>
 #include <memory>
-#include <string>
 #include <ctime>
 #include "ast.h"
 #include "nodes.h"

--- a/src/rcdgen/file_writing.h
+++ b/src/rcdgen/file_writing.h
@@ -11,7 +11,6 @@
 #define FILE_WRITING_H
 
 #include <list>
-#include <string>
 
 /** A block in an RCD file. See #StartSave for details on usage. */
 class FileBlock {

--- a/src/rcdgen/image.h
+++ b/src/rcdgen/image.h
@@ -11,7 +11,6 @@
 #define IMAGE_H
 
 #include <png.h>
-#include <string>
 
 /** Bitmask description. */
 class BitMaskData {

--- a/src/rcdgen/nodes.h
+++ b/src/rcdgen/nodes.h
@@ -10,7 +10,6 @@
 #ifndef NODES_H
 #define NODES_H
 
-#include <string>
 #include <list>
 #include <vector>
 #include <set>

--- a/src/rcdgen/scanner_funcs.h
+++ b/src/rcdgen/scanner_funcs.h
@@ -10,7 +10,6 @@
 #ifndef SCANNER_FUNCS_H
 #define SCANNER_FUNCS_H
 
-#include <string>
 #include "ast.h"
 #include "../stdafx.h"
 

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -85,6 +85,7 @@
 #include <climits>
 #include <cassert>
 #include <algorithm>
+#include <string>
 
 #if defined(UNIX) || defined(__MINGW32__)
 	#include <sys/types.h>

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -18,7 +18,6 @@
 #include "gamecontrol.h"
 #include "window.h"
 #include "viewport.h"
-#include <string>
 
 VideoSystem _video;  ///< Video sub-system.
 

--- a/src/windows/fileio_windows.cpp
+++ b/src/windows/fileio_windows.cpp
@@ -14,7 +14,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <windows.h>
-#include <string>
 
 WindowsDirectoryReader::WindowsDirectoryReader() : DirectoryReader('\\')
 {

--- a/src/windows/fileio_windows.h
+++ b/src/windows/fileio_windows.h
@@ -12,7 +12,6 @@
 
 #include "../fileio.h"
 #include "../stdafx.h"
-#include <string>
 #include <windows.h>
 
 /**


### PR DESCRIPTION
Left the #include <string> in 'src/rcdgen/ast.h' as the generated parser doesn't seem to include stdafx.h
