### PR TITLE
Add: Pan with GuiWindows open

### DIFF
--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -287,7 +287,7 @@ public:
 	void SetWidgetStringParameters(WidgetNumber wid_num) const override;
 	void OnClick(WidgetNumber widget, const Point16 &pos) override;
 
-	void SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos) override;
+	bool SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos) override;
 	void SelectorMouseButtonEvent(uint8 state) override;
 
 private:
@@ -626,23 +626,31 @@ void CoasterBuildWindow::SetupSelection()
 	this->piece_selector.pos_piece.piece = nullptr;
 }
 
-void CoasterBuildWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
+/**
+ * Handles coaster build mouse movement events
+ * @param vp Viewport
+ * @param pos Mouse position
+ * @return True if the event no longer needs to be handled (currently always false)
+ */
+bool CoasterBuildWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
 {
-	if (this->selector == nullptr || this->piece_selector.pos_piece.piece == nullptr) return; // No active selector.
-	if (this->sel_piece == nullptr || this->cur_piece != nullptr) return; // No piece, or fixed position.
+	if (this->selector == nullptr || this->piece_selector.pos_piece.piece == nullptr) return false; // No active selector.
+	if (this->sel_piece == nullptr || this->cur_piece != nullptr) return false; // No piece, or fixed position.
 
 	FinderData fdata(CS_GROUND, FW_TILE);
-	if (vp->ComputeCursorPosition(&fdata) != CS_GROUND) return;
+	if (vp->ComputeCursorPosition(&fdata) != CS_GROUND) return false;
 	XYZPoint16 &piece_base = this->piece_selector.pos_piece.base_voxel;
 	int dx = fdata.voxel_pos.x - piece_base.x;
 	int dy = fdata.voxel_pos.y - piece_base.y;
-	if (dx == 0 && dy == 0) return;
+	if (dx == 0 && dy == 0) return false;
 
 	this->piece_selector.MarkDirty();
 
 	this->piece_selector.SetPosition(this->piece_selector.area.base.x + dx, this->piece_selector.area.base.y + dy);
 	uint8 height = _world.GetTopGroundHeight(fdata.voxel_pos.x, fdata.voxel_pos.y);
 	this->piece_selector.SetTrackPiece(XYZPoint16(fdata.voxel_pos.x, fdata.voxel_pos.y, height), this->sel_piece);
+
+	return false;
 }
 
 void CoasterBuildWindow::SelectorMouseButtonEvent(uint8 state)

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -37,7 +37,7 @@ struct Point {
 	 * @param y Y coordinate.
 	 */
 	template <typename OCT>
-	Point<CT>(Point<OCT>& that) :
+	Point<CT>(const Point<OCT>& that) :
 		x(static_cast<CT>(that.x)),
 		y(static_cast<CT>(that.y))
 	{

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -29,10 +29,51 @@ struct Point {
 		this->y = y;
 	}
 
+	/**
+	 * Cast constructor. Allows conversion between 16-bit and 32-bit points.
+	 * @note This function does no bounds checking. The underlying types control the behavior of the cast; if you cast a 32-bit value to a 16-bit value, you get what you get.
+	 * @tparam OCT Other coordinate type
+	 * @param x X coordinate.
+	 * @param y Y coordinate.
+	 */
+	template <typename OCT>
+	Point<CT>(Point<OCT>& that) :
+		x(static_cast<CT>(that.x)),
+		y(static_cast<CT>(that.y))
+	{
+
+	}
+
 	typedef CT CoordType; ///< Type of the coordinate value.
 
 	CT x; ///< X coordinate.
 	CT y; ///< Y coordinate.
+
+	/**
+	 * Addition operator
+	 * @param r Right hand side
+	 * @return Point with x = this->x + r.x, y = this->y + r.y
+	 */
+	Point<CT> operator+(const Point<CT>& r) const {
+		return Point<CT>(this->x + r.x, this->y + r.y);
+	}
+
+	/**
+	 * Negation operator
+	 * @return Point with x = -that.x, y = -that.y
+	 */
+	Point<CT> operator-() const {
+		return Point<CT>(-this->x, -this->y);
+	}
+
+	/**
+	 * Subtraction operator
+	 * @param r Right hand side
+	 * @return Point with x = this->x - r.x, y = this->y - r.y
+	 */
+	Point<CT> operator-(const Point<CT>& r) const {
+		return (*this) + (-r);
+	}
 };
 
 typedef Point<int32> Point32; ///< 32 bit 2D point.

--- a/src/palette.h
+++ b/src/palette.h
@@ -14,46 +14,42 @@ class Random;
 
 extern const uint32 _palette[256];  ///< The 8bpp FreeRCT palette.
 
-/**
- * The index into _palette where a given color starts
- */
+/** The index into _palette where a given color starts. */
 enum PaletteColorStartIndex {
-	PCSI_GRAY				= 10 + ( 0 * 12),
-	PCSI_GREEN_BROWN		= 10 + ( 1 * 12),
-	PCSI_ORANGE_BORWN		= 10 + ( 2 * 12),
-	PCSI_YELLOW				= 10 + ( 3 * 12),
-	PCSI_DARK_RED			= 10 + ( 4 * 12),
-	PCSI_DARK_GREEN			= 10 + ( 5 * 12),
-	PCSI_LIGHT_GREEN		= 10 + ( 6 * 12),
-	PCSI_GREEN				= 10 + ( 7 * 12),
-	PCSI_PINK_BROWN			= 10 + ( 8 * 12),
-	PCSI_DARK_PURPLE		= 10 + ( 9 * 12),
-	PCSI_BLUE				= 10 + (10 * 12),
-	PCSI_DARK_JADE_GREEN	= 10 + (11 * 12),
-	PCSI_PURPLE				= 10 + (12 * 12),
-	PCSI_RED				= 10 + (13 * 12),
-	PCSI_ORANGE				= 10 + (14 * 12),
-	PCSI_SEA_GREEN			= 10 + (15 * 12),
-	PCSI_PINK				= 10 + (16 * 12),
-	PCSI_BROWN				= 10 + (17 * 12)
+	PCSI_GRAY            = 10 + ( 0 * 12),
+	PCSI_GREEN_BROWN     = 10 + ( 1 * 12),
+	PCSI_ORANGE_BORWN    = 10 + ( 2 * 12),
+	PCSI_YELLOW          = 10 + ( 3 * 12),
+	PCSI_DARK_RED        = 10 + ( 4 * 12),
+	PCSI_DARK_GREEN      = 10 + ( 5 * 12),
+	PCSI_LIGHT_GREEN     = 10 + ( 6 * 12),
+	PCSI_GREEN           = 10 + ( 7 * 12),
+	PCSI_PINK_BROWN      = 10 + ( 8 * 12),
+	PCSI_DARK_PURPLE     = 10 + ( 9 * 12),
+	PCSI_BLUE            = 10 + (10 * 12),
+	PCSI_DARK_JADE_GREEN = 10 + (11 * 12),
+	PCSI_PURPLE          = 10 + (12 * 12),
+	PCSI_RED             = 10 + (13 * 12),
+	PCSI_ORANGE          = 10 + (14 * 12),
+	PCSI_SEA_GREEN       = 10 + (15 * 12),
+	PCSI_PINK            = 10 + (16 * 12),
+	PCSI_BROWN           = 10 + (17 * 12)
 };
 
-/**
- * The brightness / darknes of a color in _palette
- */
+/** The brightness / darkness of a color in _palette. */
 enum PaletteColorIntensity {
-	PCI_DARKEST = 0,
-	PCI_VERY_DARK = 1,
-	PCI_DARK = 2,
-	PCI_MED_DARK = 3,
-	PCI_MILD_DARK = 4,
-	PCI_VERY_MILD_DARK = 5,
-	PCI_VERY_MILD_BRIGHT = 6,
-	PCI_MILD_BRIGHT = 7,
-	PCI_MED_BRIGHT = 8,
-	PCI_BRIGHT = 9,
-	PCI_VERY_BRIGHT = 10,
-	PCI_BRIGHTEST = 11
+	PCI_DARKEST          =  0,
+	PCI_VERY_DARK        =  1,
+	PCI_DARK             =  2,
+	PCI_MED_DARK         =  3,
+	PCI_MILD_DARK        =  4,
+	PCI_VERY_MILD_DARK   =  5,
+	PCI_VERY_MILD_BRIGHT =  6,
+	PCI_MILD_BRIGHT      =  7,
+	PCI_MED_BRIGHT       =  8,
+	PCI_BRIGHT           =  9,
+	PCI_VERY_BRIGHT      = 10,
+	PCI_BRIGHTEST        = 11
 };
 
 /**
@@ -62,9 +58,9 @@ enum PaletteColorIntensity {
  * @param n Desired intensity
  * @return Index into _palette where the given color may be found
  */
-inline char GetColorInFreeRCTPalette(PaletteColorStartIndex i,
-									 PaletteColorIntensity n) {
-	return i + n;
+inline static const uint32 GetColor(PaletteColorStartIndex i, PaletteColorIntensity  n)
+{
+        return _palette[i + n];
 }
 
 extern const uint32 * const _recolour_palettes[18]; ///< 32bpp recolour tables.

--- a/src/palette.h
+++ b/src/palette.h
@@ -13,6 +13,60 @@
 class Random;
 
 extern const uint32 _palette[256];  ///< The 8bpp FreeRCT palette.
+
+/**
+ * The index into _palette where a given color starts
+ */
+enum PaletteColorStartIndex {
+	PCSI_GRAY				= 10 + ( 0 * 12),
+	PCSI_GREEN_BROWN		= 10 + ( 1 * 12),
+	PCSI_ORANGE_BORWN		= 10 + ( 2 * 12),
+	PCSI_YELLOW				= 10 + ( 3 * 12),
+	PCSI_DARK_RED			= 10 + ( 4 * 12),
+	PCSI_DARK_GREEN			= 10 + ( 5 * 12),
+	PCSI_LIGHT_GREEN		= 10 + ( 6 * 12),
+	PCSI_GREEN				= 10 + ( 7 * 12),
+	PCSI_PINK_BROWN			= 10 + ( 8 * 12),
+	PCSI_DARK_PURPLE		= 10 + ( 9 * 12),
+	PCSI_BLUE				= 10 + (10 * 12),
+	PCSI_DARK_JADE_GREEN	= 10 + (11 * 12),
+	PCSI_PURPLE				= 10 + (12 * 12),
+	PCSI_RED				= 10 + (13 * 12),
+	PCSI_ORANGE				= 10 + (14 * 12),
+	PCSI_SEA_GREEN			= 10 + (15 * 12),
+	PCSI_PINK				= 10 + (16 * 12),
+	PCSI_BROWN				= 10 + (17 * 12)
+};
+
+/**
+ * The brightness / darknes of a color in _palette
+ */
+enum PaletteColorIntensity {
+	PCI_DARKEST = 0,
+	PCI_VERY_DARK = 1,
+	PCI_DARK = 2,
+	PCI_MED_DARK = 3,
+	PCI_MILD_DARK = 4,
+	PCI_VERY_MILD_DARK = 5,
+	PCI_VERY_MILD_BRIGHT = 6,
+	PCI_MILD_BRIGHT = 7,
+	PCI_MED_BRIGHT = 8,
+	PCI_BRIGHT = 9,
+	PCI_VERY_BRIGHT = 10,
+	PCI_BRIGHTEST = 11
+};
+
+/**
+ * Get the index of the desired color in the initially-defined color palette.
+ * @param i Desired color
+ * @param n Desired intensity
+ * @return Index into _palette where the given color may be found
+ */
+inline char GetColorInFreeRCTPalette(PaletteColorStartIndex i,
+									 PaletteColorIntensity n) {
+	return i + n;
+}
+
 extern const uint32 * const _recolour_palettes[18]; ///< 32bpp recolour tables.
 
 static const int MAX_RECOLOUR = 4;  ///< Maximum number of recolourings that can be defined in a #Recolouring class.

--- a/src/ride_build.cpp
+++ b/src/ride_build.cpp
@@ -74,7 +74,7 @@ public:
 	void DrawWidget(WidgetNumber wid_num, const BaseWidget *wid) const override;
 	void OnClick(WidgetNumber wid_num, const Point16 &pos) override;
 
-	void SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos) override;
+	bool SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos) override;
 	void SelectorMouseButtonEvent(uint8 state) override;
 
 	RideMouseMode selector; ///< Mouse mode displaying the new ride.
@@ -255,7 +255,13 @@ RidePlacementResult RideBuildWindow::ComputeShopVoxel(XYZPoint32 world_pos, View
 	return RPR_FAIL;
 }
 
-void RideBuildWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
+/**
+ * Handles mouse movement input
+ * @param vp %Viewport where the mouse movement occured
+ * @param pos New mouse position
+ * @return True if the event no longer needs to be handled (currently always false)
+ */
+bool RideBuildWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
 {
 	Point32 wxy = vp->ComputeHorizontalTranslation(vp->rect.width / 2 - pos.x, vp->rect.height / 2 - pos.y);
 
@@ -264,7 +270,7 @@ void RideBuildWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
 		case RPR_FAIL:
 			this->selector.MarkDirty(); // Does not do anything with a zero-sized mouse selector.
 			this->selector.SetSize(0, 0);
-			return;
+			return false;
 
 		case RPR_SAMEPOS:
 		case RPR_CHANGED: {
@@ -283,7 +289,7 @@ void RideBuildWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
 			uint8 entrances = si->GetEntranceDirections(si->vox_pos);
 			this->selector.SetRideData(si->vox_pos, inst_number, entrances);
 			this->selector.MarkDirty();
-			return;
+			return false;
 		}
 
 		default: NOT_REACHED();

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -29,7 +29,7 @@ public:
 	void OnClick(WidgetNumber widget, const Point16 &pos) override;
 
 	void SelectorMouseWheelEvent(int direction) override;
-	void SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos) override;
+	bool SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos) override;
 
 	bool level; ///< If true, level the area, else move it up/down as-is.
 	int xsize;  ///< Size of the terraform area in horizontal direction.
@@ -103,21 +103,29 @@ void TerraformGui::SelectorMouseWheelEvent(int direction)
 	this->tiles_selector.InitTileData();
 }
 
-void TerraformGui::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
+/**
+ * Handles mouse movement input
+ * @param vp %Viewport where the mouse movement occured
+ * @param pos New mouse position
+ * @return True if the event no longer needs to be handled (currently always false)
+ */
+bool TerraformGui::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
 {
-	if (this->selector == nullptr) return;
+	if (this->selector == nullptr) return false;
 
 	FinderData fdata(CS_GROUND, (this->xsize <= 1 && this->ysize <= 1) ? FW_CORNER : FW_TILE);
-	if (vp->ComputeCursorPosition(&fdata) != CS_GROUND) return;
+	if (vp->ComputeCursorPosition(&fdata) != CS_GROUND) return false;
 	Rectangle16 &sel_rect = this->tiles_selector.area;
 	int xsel = sel_rect.base.x + sel_rect.width / 2;
 	int ysel = sel_rect.base.y + sel_rect.height / 2;
-	if (fdata.cursor == this->tiles_selector.cur_cursor && fdata.voxel_pos.x == xsel && fdata.voxel_pos.y == ysel) return;
+	if (fdata.cursor == this->tiles_selector.cur_cursor && fdata.voxel_pos.x == xsel && fdata.voxel_pos.y == ysel) return false;
 
 	this->tiles_selector.MarkDirty();
 	this->tiles_selector.cur_cursor = fdata.cursor; // Copy cursor and position.
 	this->tiles_selector.SetPosition(fdata.voxel_pos.x - sel_rect.width / 2, fdata.voxel_pos.y - sel_rect.height / 2);
 	this->tiles_selector.MarkDirty();
+
+	return false;
 }
 
 void TerraformGui::DrawWidget(WidgetNumber wid_num, const BaseWidget *wid) const

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -670,8 +670,8 @@ void SpriteCollector::CollectVoxel(const Voxel *voxel, const XYZPoint16 &voxel_p
 		if (anim_spr != nullptr) {
 			int x_off = ComputeX(vo->pix_pos.x, vo->pix_pos.y);
 			int y_off = ComputeY(vo->pix_pos.x, vo->pix_pos.y, vo->pix_pos.z);
-			Point32 pos(north_point.x + this->north_offsets[this->orient].x + x_off,
-			            north_point.y + this->north_offsets[this->orient].y + y_off);
+			Point32 offset(x_off, y_off);
+			Point32 pos = north_point + offset + this->north_offsets[this->orient];
 			DrawData dd;
 			dd.Set(slice, voxel_pos.z, SO_PERSON, anim_spr, pos, recolour);
 			this->draw_images.insert(dd);
@@ -1010,35 +1010,31 @@ ClickableSprite Viewport::ComputeCursorPosition(FinderData *fdata)
 	if (!collector.found) return CS_NONE;
 
 	fdata->cursor = fdata->select == FW_EDGE ? CUR_TYPE_EDGE_NE : CUR_TYPE_TILE;
-// Temporary use of shorter name
-#define GETCOLOR(x, y) ( _palette[GetColorInFreeRCTPalette(x, y)] )
 	if (fdata->select == FW_CORNER && (collector.data.order & CS_MASK) == CS_GROUND) {
-		if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MED_DARK)) {
+		if (collector.pixel == GetColor(PCSI_ORANGE, PCI_MED_DARK)) {
 			fdata->cursor = (CursorType)AddOrientations(VOR_NORTH, this->orientation);
-		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MILD_DARK)) {
+		} else if (collector.pixel == GetColor(PCSI_ORANGE, PCI_MILD_DARK)) {
 			fdata->cursor = (CursorType)AddOrientations(VOR_EAST,  this->orientation);
-		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_VERY_MILD_BRIGHT)) {
+		} else if (collector.pixel == GetColor(PCSI_ORANGE, PCI_VERY_MILD_BRIGHT)) {
 			fdata->cursor = (CursorType)AddOrientations(VOR_WEST,  this->orientation);
-		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MILD_BRIGHT)) {
+		} else if (collector.pixel == GetColor(PCSI_ORANGE, PCI_MILD_BRIGHT)) {
 			fdata->cursor = (CursorType)AddOrientations(VOR_SOUTH, this->orientation);
 		}
 	}
 	else if (fdata->select == FW_EDGE && (collector.data.order & CS_MASK) == CS_GROUND_EDGE) {
 		uint8 base_edge = EDGE_COUNT;
-		if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MED_DARK)) {
+		if (collector.pixel == GetColor(PCSI_ORANGE, PCI_MED_DARK)) {
 			base_edge = (uint8)EDGE_NE;
-		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MILD_DARK)) {
+		} else if (collector.pixel == GetColor(PCSI_ORANGE, PCI_MILD_DARK)) {
 			base_edge = (uint8)EDGE_SE;
-		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_VERY_MILD_BRIGHT)) {
+		} else if (collector.pixel == GetColor(PCSI_ORANGE, PCI_VERY_MILD_BRIGHT)) {
 			base_edge = (uint8)EDGE_NW;
-		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MILD_BRIGHT)) {
+		} else if (collector.pixel == GetColor(PCSI_ORANGE, PCI_MILD_BRIGHT)) {
 			base_edge = (uint8)EDGE_SW;
 		}
 		if (base_edge < EDGE_COUNT) {
 			fdata->cursor = (CursorType)((base_edge + (uint8)this->orientation) % 4 + (uint8)CUR_TYPE_EDGE_NE);
 		}
-// Done with the macro, unclutter the translation unit
-#undef GETCOLOR
 	}
 	return (ClickableSprite)(collector.data.order & CS_MASK);
 }

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1010,31 +1010,35 @@ ClickableSprite Viewport::ComputeCursorPosition(FinderData *fdata)
 	if (!collector.found) return CS_NONE;
 
 	fdata->cursor = fdata->select == FW_EDGE ? CUR_TYPE_EDGE_NE : CUR_TYPE_TILE;
+// Temporary use of shorter name
+#define GETCOLOR(x, y) ( _palette[GetColorInFreeRCTPalette(x, y)] )
 	if (fdata->select == FW_CORNER && (collector.data.order & CS_MASK) == CS_GROUND) {
-		if (collector.pixel == _palette[181]) {
+		if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MED_DARK)) {
 			fdata->cursor = (CursorType)AddOrientations(VOR_NORTH, this->orientation);
-		} else if (collector.pixel == _palette[182]) {
+		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MILD_DARK)) {
 			fdata->cursor = (CursorType)AddOrientations(VOR_EAST,  this->orientation);
-		} else if (collector.pixel == _palette[184]) {
+		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_VERY_MILD_BRIGHT)) {
 			fdata->cursor = (CursorType)AddOrientations(VOR_WEST,  this->orientation);
-		} else if (collector.pixel == _palette[185]) {
+		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MILD_BRIGHT)) {
 			fdata->cursor = (CursorType)AddOrientations(VOR_SOUTH, this->orientation);
 		}
 	}
 	else if (fdata->select == FW_EDGE && (collector.data.order & CS_MASK) == CS_GROUND_EDGE) {
 		uint8 base_edge = EDGE_COUNT;
-		if (collector.pixel == _palette[181]) {
+		if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MED_DARK)) {
 			base_edge = (uint8)EDGE_NE;
-		} else if (collector.pixel == _palette[182]) {
+		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MILD_DARK)) {
 			base_edge = (uint8)EDGE_SE;
-		} else if (collector.pixel == _palette[184]) {
+		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_VERY_MILD_BRIGHT)) {
 			base_edge = (uint8)EDGE_NW;
-		} else if (collector.pixel == _palette[185]) {
+		} else if (collector.pixel == GETCOLOR(PCSI_ORANGE, PCI_MILD_BRIGHT)) {
 			base_edge = (uint8)EDGE_SW;
 		}
 		if (base_edge < EDGE_COUNT) {
 			fdata->cursor = (CursorType)((base_edge + (uint8)this->orientation) % 4 + (uint8)CUR_TYPE_EDGE_NE);
 		}
+// Done with the macro, unclutter the translation unit
+#undef GETCOLOR
 	}
 	return (ClickableSprite)(collector.data.order & CS_MASK);
 }


### PR DESCRIPTION
Changes:
- OnSelectorMoseMove() returns bool instead of void for all GuiWindows
  - Return value tells whether the mouse event should fall through to the viewport if the mouse is on the viewport
- Window manager gets new state: WMMM_MOUSE_DOWN
  - State causes all mouse move events to get routed to the "focus_holder", the window where the mouse was first clicked on, until the mouse button is released
- Point<T> now has operators
- _palette[] has a second way to specify the color without using magic numbers
  - This is used to remove the magic numbers in viewort.cpp
- Changes to PathGui to make it work more intuitively:
  - Right click still moves the viewport if it starts on a non-path
  - Right click goes into a "delete mode" and does not move the viewport if you start the right-click on a path
  - Fast mouse motion does not move the voxel highlight, nor does it cause a switch from "move" to "destroy" mode
