### PR TITLE
Port image processing tools to python to allow 32bpp sprite sheet rendering

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -38,6 +38,7 @@ jjhdnd           GUI
 PovAddictW       FileIO
 stanekj          Rides
 tnt.freesoftware GUI
+Paul Page        Graphics
 ================ ========
 
 

--- a/graphics/sprites/info_and_scripts/mergeRenders.py
+++ b/graphics/sprites/info_and_scripts/mergeRenders.py
@@ -1,0 +1,62 @@
+"""
+This file is part of FreeRCT.
+FreeRCT is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+FreeRCT is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with FreeRCT. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from PIL import Image
+import os
+import math
+import argparse
+
+#tile widths to expect for renders
+tilew = (64, 128, 256)
+
+#length of string for tile index number
+indexleng = 5
+
+#parser for command line arguements
+parser = argparse.ArgumentParser(description = "Merge sprites in a directory into a sprite sheet.")
+parser.add_argument("fpath", help = "directory to work in")
+parser.add_argument("w", help = "columns in sprite sheet (default: 4)", type = int, nargs="?", default = "4")
+parser.add_argument("h", help = "rows in sprite sheet (default: 8)", type = int, nargs="?", default = "8")
+parser.add_argument("autoh", help = "whether or not to auto-count the rows in the sprite sheet (default: True)", type = bool, nargs="?", default = "True")
+parser.add_argument("tiw", help = "X scale factor (default: 1)", type = int, nargs="?", default = "1")
+parser.add_argument("tih", help = "Y scale factor (default: 1)", type = int, nargs="?", default = "1")
+args = parser.parse_args()
+
+#parameters: directory, columns, rows, auto-count, x size factor, y size factor
+def mergeRenders(fpath, w, h, autoh, tiw, tih):
+    #additional directory variables
+    fpath = fpath.rstrip(os.sep)
+    path = os.path.abspath(os.path.join(fpath, os.pardir)) + os.sep
+    name = os.path.basename(fpath)
+
+    if autoh == True:
+        #count for auto height
+        for i in tilew:
+            j = 1
+            string = str(j).zfill(indexleng)
+            while os.path.exists(path + name + os.sep + str(i) + "_" + string + ".png") == True:
+                j += 1
+                string = str(j).zfill(indexleng)
+        h = math.floor((j - 1) / w)
+
+    #loop through tile widths
+    for i in tilew:
+        #calculate output image size and make output image
+        iw = i * tiw * w
+        ih = i * tih * h
+        final = Image.new('RGBA', (iw,ih), (255, 0, 0, 0))
+        j = 1
+        string = str(j).zfill(indexleng)
+        while os.path.exists(path + name + os.sep + str(i) + "_" + string + ".png") == True:
+            img = Image.open(path + name + os.sep + str(i) + "_" + string + ".png")
+            final.paste(img, (((j - 1) % w) * i * tiw, math.floor((j - 1) / w) * i * tih))
+            j += 1
+            string = str(j).zfill(indexleng)
+        final.save(path + name + str(i) + ".png", "PNG")
+
+#run main function
+mergeRenders(**vars(args))

--- a/graphics/sprites/info_and_scripts/spriteSheetMasking.py
+++ b/graphics/sprites/info_and_scripts/spriteSheetMasking.py
@@ -1,0 +1,49 @@
+"""
+This file is part of FreeRCT.
+FreeRCT is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+FreeRCT is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with FreeRCT. If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from PIL import Image
+import os
+import argparse
+
+#tile widths to expect for renders
+tilew = (64, 128, 256)
+
+#parser for command line arguments
+parser = argparse.ArgumentParser(description = "Merge sprites in a directory into a sprite sheet.")
+parser.add_argument("fpath", help = "directory to work in")
+args = parser.parse_args()
+
+def mask(fpath):
+    fpath = fpath.rstrip(os.sep)
+    filearr = [f for f in os.listdir(fpath) if os.path.isfile(os.path.join(fpath, f))]
+    for i in filearr:
+        if i.endswith(".png"):
+            for j in tilew:
+                name = os.path.splitext(i)[0]
+                print(name)
+                if name.endswith(str(j)):
+                    for k in range(3):
+                        if k == 0:
+                            string = ""
+                        else:
+                            string = str(k)
+                        final = Image.open(fpath + os.sep + name + ".png")
+                        maskSource = Image.open(fpath + os.sep + "mask" + os.sep + str(j) + "px" + string + ".png")
+                        width, height = final.size
+                        mask = Image.new('RGBA', (width,height), (255, 0, 0, 0))
+                        mheight = maskSource.size[1]
+                        for l in range(int(height / mheight)):
+                            mask.paste(maskSource, (0, mheight * l))
+                        mask_p = mask.load()
+                        final_p = final.load()
+                        for y in range(height):
+                            for x in range(width):
+                                if mask_p[x,y] == 0 or mask_p[x,y] == (0,0,0,255):
+                                    final_p[x,y] = (255, 0, 0, 0)
+                        final.save(fpath + os.sep + name + "_masked" + string + ".png", "PNG")
+
+mask(**vars(args))


### PR DESCRIPTION
I noticed that imagej does not support alpha channels, thus making it impossible to use the existing sprite sheet creation and masking scripts to render 32bpp sprite sheets. So I ported the macros to python. This allows rendering 32bpp sprite sheets with transparent backgrounds. 

Issues:
- 32bpp rendering of the tileselection sprites makes it hard to select corners when terraforming. 

Requirements to run scripts:
- Python3
- Pillow
- Tkinter
