### PR TITLE
Add: Improvements to CoasterBuildWindow and CoasterInstanceWindow

### DIFF
--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -604,6 +604,28 @@ void CoasterInstance::OnAnimate(int delay)
 	}
 }
 
+void CoasterInstance::TestRide()
+{
+	if (this->state != RIS_TESTING) {
+		this->CloseRide();
+		this->state = RIS_TESTING;
+	}
+	this->DecideRideState();
+}
+
+void CoasterInstance::CloseRide()
+{
+	for (uint i = 0; i < lengthof(this->trains); i++) {
+		CoasterTrain &train = this->trains[i];
+		train.back_position = 0;
+		train.speed = 0;
+		train.cur_piece = this->pieces;
+		train.cars.resize(0);
+		train.OnAnimate(0);
+	}
+	RideInstance::CloseRide();
+}
+
 void CoasterInstance::GetSprites(uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const
 {
 	const CoasterType *ct = this->GetCoasterType();

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -196,6 +196,7 @@ public:
 	bool IsAccessible();
 
 	void OnAnimate(int delay) override;
+	void CloseRide() override;
 
 	/**
 	 * Get the coaster type of this ride.
@@ -205,6 +206,8 @@ public:
 	{
 		return static_cast<const CoasterType *>(this->type);
 	}
+
+	void TestRide();
 
 	void GetSprites(uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const override;
 	uint8 GetEntranceDirections(const XYZPoint16 &vox) const override;

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -154,7 +154,7 @@ public:
 	void OnNewDay();
 	void BuildRide();
 	void OpenRide();
-	void CloseRide();
+	virtual void CloseRide();
 	void HandleBreakdown();
 
 	virtual void Load(Loader &ldr);


### PR DESCRIPTION
- Implemented `OnClick` logic for `CCW_BACKWARD` and `CCW_FORWARD` buttons in `CoasterBuildWindow`.
- Modified CoasterBuildWindow to handle deleting track not at the front of the coaster.
- Added `CIW_EDIT` button to `CoasterInstanceWindow` to allow editing existing coasters.
- Added `CIW_CLOSE`, `CIW_TEST` and `CIW_OPEN`  buttons to `CoasterInstanceWindow` control the state of coaster.