### PR TITLE
Remove deleted rides from world

### DIFF
--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -721,6 +721,22 @@ int CoasterInstance::GetFirstPlacedTrackPiece() const
 	return -1;
 }
 
+std::vector<XYZPoint16> CoasterInstance::get_all_positions() {
+	std::vector<XYZPoint16> result;
+
+	const int start_piece = GetFirstPlacedTrackPiece();
+	if (start_piece < 0) return result;
+
+	result.push_back(this->pieces[start_piece].base_voxel);
+	for (int p = start_piece;;) {
+		p = FindSuccessorPiece(this->pieces[p]);
+		if (p < 0 || p == start_piece) break;
+		result.push_back(this->pieces[p].base_voxel);
+	}
+
+	return result;
+}
+
 /**
  * Find the first placed track piece at a given position with a given entry connection.
  * @param vox Required voxel position.

--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -721,18 +721,16 @@ int CoasterInstance::GetFirstPlacedTrackPiece() const
 	return -1;
 }
 
-std::vector<XYZPoint16> CoasterInstance::GetAllPiecePositions() {
-	std::vector<XYZPoint16> result;
+void CoasterInstance::RemoveFromWorld()
+{
+	const uint16 index = this->GetIndex();
 	const int start_piece = GetFirstPlacedTrackPiece();
-	if (start_piece < 0) return result;
+	if (start_piece < 0) return;
 	for (int p = start_piece;;) {
-		for (const TrackVoxel *subpiece : this->pieces[p].piece->track_voxels) {
-			result.emplace_back(this->pieces[p].base_voxel + subpiece->dxyz);
-		}
+		this->pieces[p].RemoveFromWorld(index);
 		p = FindSuccessorPiece(this->pieces[p]);
 		if (p < 0 || p == start_piece) break;
 	}
-	return result;
 }
 
 /**

--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -721,17 +721,17 @@ int CoasterInstance::GetFirstPlacedTrackPiece() const
 	return -1;
 }
 
-std::vector<XYZPoint16> CoasterInstance::get_all_positions() {
+std::vector<XYZPoint16> CoasterInstance::GetAllPiecePositions() {
 	std::vector<XYZPoint16> result;
 
 	const int start_piece = GetFirstPlacedTrackPiece();
 	if (start_piece < 0) return result;
 
-	result.push_back(this->pieces[start_piece].base_voxel);
+	result.emplace_back(this->pieces[start_piece].base_voxel);
 	for (int p = start_piece;;) {
 		p = FindSuccessorPiece(this->pieces[p]);
 		if (p < 0 || p == start_piece) break;
-		result.push_back(this->pieces[p].base_voxel);
+		result.emplace_back(this->pieces[p].base_voxel);
 	}
 
 	return result;

--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -723,19 +723,14 @@ int CoasterInstance::GetFirstPlacedTrackPiece() const
 
 std::vector<XYZPoint16> CoasterInstance::GetAllPiecePositions() {
 	std::vector<XYZPoint16> result;
-
 	const int start_piece = GetFirstPlacedTrackPiece();
-	if (start_piece < 0) return result;
-
-	result.emplace_back(this->pieces[start_piece].base_voxel);
 	for (int p = start_piece;;) {
-		p = FindSuccessorPiece(this->pieces[p]);
-		if (p < 0 || p == start_piece) break;
 		for (const TrackVoxel *subpiece : this->pieces[p].piece->track_voxels) {
 			result.emplace_back(this->pieces[p].base_voxel + subpiece->dxyz);
 		}
+		p = FindSuccessorPiece(this->pieces[p]);
+		if (p < 0 || p == start_piece) break;
 	}
-
 	return result;
 }
 

--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -731,7 +731,9 @@ std::vector<XYZPoint16> CoasterInstance::GetAllPiecePositions() {
 	for (int p = start_piece;;) {
 		p = FindSuccessorPiece(this->pieces[p]);
 		if (p < 0 || p == start_piece) break;
-		result.emplace_back(this->pieces[p].base_voxel);
+		for (const TrackVoxel *subpiece : this->pieces[p].piece->track_voxels) {
+			result.emplace_back(this->pieces[p].base_voxel + subpiece->dxyz);
+		}
 	}
 
 	return result;

--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -724,6 +724,7 @@ int CoasterInstance::GetFirstPlacedTrackPiece() const
 std::vector<XYZPoint16> CoasterInstance::GetAllPiecePositions() {
 	std::vector<XYZPoint16> result;
 	const int start_piece = GetFirstPlacedTrackPiece();
+	if (start_piece < 0) return result;
 	for (int p = start_piece;;) {
 		for (const TrackVoxel *subpiece : this->pieces[p].piece->track_voxels) {
 			result.emplace_back(this->pieces[p].base_voxel + subpiece->dxyz);

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -242,7 +242,7 @@ public:
 	void Load(Loader &ldr);
 	void Save(Saver &svr);
 
-	std::vector<XYZPoint16> get_all_positions() override;
+	std::vector<XYZPoint16> GetAllPiecePositions() override;
 
 	PositionedTrackPiece *pieces; ///< Positioned track pieces.
 	int capacity;                 ///< Number of entries in the #pieces.

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -242,6 +242,8 @@ public:
 	void Load(Loader &ldr);
 	void Save(Saver &svr);
 
+	std::vector<XYZPoint16> get_all_positions() override;
+
 	PositionedTrackPiece *pieces; ///< Positioned track pieces.
 	int capacity;                 ///< Number of entries in the #pieces.
 	uint32 coaster_length;        ///< Total length of the roller coaster track (in 1/256 pixels).

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -242,7 +242,7 @@ public:
 	void Load(Loader &ldr);
 	void Save(Saver &svr);
 
-	std::vector<XYZPoint16> GetAllPiecePositions() override;
+	void RemoveFromWorld() override;
 
 	PositionedTrackPiece *pieces; ///< Positioned track pieces.
 	int capacity;                 ///< Number of entries in the #pieces.

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -222,8 +222,8 @@ const RideType *RideInstance::GetRideType() const
  */
 
 /**
- * \fn void RideInstance::GetAllPiecePositions()
- * Returns a vector with the coordinates of all voxels which are occupied by this ride.
+ * \fn void RideInstance::RemoveFromWorld()
+ * Immediately remove this ride from all voxels it currently occupies.
  */
 
 /**
@@ -691,16 +691,7 @@ void RidesManager::DeleteInstance(uint16 num)
 	assert(num < lengthof(this->instances));
 	this->instances[num]->RemoveAllPeople();
 	_guests.NotifyRideDeletion(this->instances[num]);
-
-	for (const XYZPoint16& position : this->instances[num]->GetAllPiecePositions()) {
-		Voxel *voxel = _world.GetCreateVoxel(position, false);
-		assert(voxel);
-		if (voxel->instance != SRI_FREE) {
-			assert(voxel->instance == num + SRI_FULL_RIDES);
-			voxel->ClearInstances();
-		}
-	}
-
+	this->instances[num]->RemoveFromWorld();
 	delete this->instances[num];
 	this->instances[num] = nullptr;
 }

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -695,8 +695,10 @@ void RidesManager::DeleteInstance(uint16 num)
 	for (const XYZPoint16& position : this->instances[num]->GetAllPiecePositions()) {
 		Voxel *voxel = _world.GetCreateVoxel(position, false);
 		assert(voxel);
-		assert(voxel->instance == num + SRI_FULL_RIDES);
-		voxel->ClearInstances();
+		if (voxel->instance != SRI_FREE) {
+			assert(voxel->instance == num + SRI_FULL_RIDES);
+			voxel->ClearInstances();
+		}
 	}
 
 	delete this->instances[num];

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -677,7 +677,6 @@ void RidesManager::NewInstanceAdded(uint16 num)
 /**
  * Destroy the indicated instance.
  * @param num The ride number to destroy.
- * @todo The small matter of cleaning up in the world map.
  * @pre Instance must be closed.
  */
 void RidesManager::DeleteInstance(uint16 num)
@@ -687,6 +686,13 @@ void RidesManager::DeleteInstance(uint16 num)
 	assert(num < lengthof(this->instances));
 	this->instances[num]->RemoveAllPeople();
 	_guests.NotifyRideDeletion(this->instances[num]);
+
+	for (const XYZPoint16& position : this->instances[num]->get_all_positions()) {
+		Voxel& voxel = *_world.GetCreateVoxel(position, false);
+		assert(voxel.instance == num + SRI_FULL_RIDES);
+		voxel.ClearInstances();
+	}
+
 	delete this->instances[num];
 	this->instances[num] = nullptr;
 }

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -222,6 +222,11 @@ const RideType *RideInstance::GetRideType() const
  */
 
 /**
+ * \fn void RideInstance::GetAllPiecePositions()
+ * Returns a vector with the coordinates of all voxels which are occupied by this ride.
+ */
+
+/**
  * Can the ride be visited, assuming it is approached from direction \a edge?
  * @param vox Position of the voxel with the ride.
  * @param edge Direction of movement (exit direction of the neighbouring voxel).
@@ -687,10 +692,11 @@ void RidesManager::DeleteInstance(uint16 num)
 	this->instances[num]->RemoveAllPeople();
 	_guests.NotifyRideDeletion(this->instances[num]);
 
-	for (const XYZPoint16& position : this->instances[num]->get_all_positions()) {
-		Voxel& voxel = *_world.GetCreateVoxel(position, false);
-		assert(voxel.instance == num + SRI_FULL_RIDES);
-		voxel.ClearInstances();
+	for (const XYZPoint16& position : this->instances[num]->GetAllPiecePositions()) {
+		Voxel *voxel = _world.GetCreateVoxel(position, false);
+		assert(voxel);
+		assert(voxel->instance == num + SRI_FULL_RIDES);
+		voxel->ClearInstances();
 	}
 
 	delete this->instances[num];

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -140,9 +140,8 @@ public:
 	virtual RideEntryResult EnterRide(int guest, TileEdge entry_edge) = 0;
 	virtual XYZPoint32 GetExit(int guest, TileEdge entry_edge) = 0;
 	virtual void RemoveAllPeople() = 0;
+	virtual std::vector<XYZPoint16> GetAllPiecePositions() = 0;
 	bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const;
-
-	virtual std::vector<XYZPoint16> get_all_positions() = 0;
 
 	void SellItem(int item_index);
 	ItemType GetSaleItemType(int item_index) const;

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -140,7 +140,7 @@ public:
 	virtual RideEntryResult EnterRide(int guest, TileEdge entry_edge) = 0;
 	virtual XYZPoint32 GetExit(int guest, TileEdge entry_edge) = 0;
 	virtual void RemoveAllPeople() = 0;
-	virtual std::vector<XYZPoint16> GetAllPiecePositions() = 0;
+	virtual void RemoveFromWorld() = 0;
 	bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const;
 
 	void SellItem(int item_index);

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -142,6 +142,8 @@ public:
 	virtual void RemoveAllPeople() = 0;
 	bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const;
 
+	virtual std::vector<XYZPoint16> get_all_positions() = 0;
+
 	void SellItem(int item_index);
 	ItemType GetSaleItemType(int item_index) const;
 	Money GetSaleItemPrice(int item_index) const;

--- a/src/shop_type.cpp
+++ b/src/shop_type.cpp
@@ -234,6 +234,17 @@ void ShopInstance::RemoveAllPeople()
 	}
 }
 
+void ShopInstance::RemoveFromWorld()
+{
+	const uint16 index = this->GetIndex();
+	Voxel *voxel = _world.GetCreateVoxel(vox_pos, false);
+	assert(voxel);
+	if (voxel->instance != SRI_FREE) {
+		assert(voxel->instance == index);
+		voxel->ClearInstances();
+	}
+}
+
 void ShopInstance::OnAnimate(int delay)
 {
 	this->onride_guests.OnAnimate(delay); // Update remaining time of onride guests.

--- a/src/shop_type.h
+++ b/src/shop_type.h
@@ -55,7 +55,7 @@ public:
 	void Load(Loader &ldr) override;
 	void Save(Saver &svr) override;
 
-	std::vector<XYZPoint16> get_all_positions() override {
+	std::vector<XYZPoint16> GetAllPiecePositions() override {
 		return {vox_pos};
 	}
 

--- a/src/shop_type.h
+++ b/src/shop_type.h
@@ -55,9 +55,7 @@ public:
 	void Load(Loader &ldr) override;
 	void Save(Saver &svr) override;
 
-	std::vector<XYZPoint16> GetAllPiecePositions() override {
-		return {vox_pos};
-	}
+	void RemoveFromWorld() override;
 
 	uint8 orientation;  ///< Orientation of the shop.
 	XYZPoint16 vox_pos; ///< Position of the shop base voxel.

--- a/src/shop_type.h
+++ b/src/shop_type.h
@@ -55,6 +55,10 @@ public:
 	void Load(Loader &ldr) override;
 	void Save(Saver &svr) override;
 
+	std::vector<XYZPoint16> get_all_positions() override {
+		return {vox_pos};
+	}
+
 	uint8 orientation;  ///< Orientation of the shop.
 	XYZPoint16 vox_pos; ///< Position of the shop base voxel.
 

--- a/src/track_piece.cpp
+++ b/src/track_piece.cpp
@@ -179,6 +179,22 @@ TrackPiece::~TrackPiece()
 }
 
 /**
+ * Immediately remove a piece of this type from all voxels it occupies.
+ * @param ride_index The index of the coaster that owns the piece.
+ * @param base_voxel the piece's absolute coordinates.
+ */
+void TrackPiece::RemoveFromWorld(const uint16 ride_index, const XYZPoint16 base_voxel) const {
+	for (const TrackVoxel *subpiece : this->track_voxels) {
+		Voxel *voxel = _world.GetCreateVoxel(base_voxel + subpiece->dxyz, false);
+		assert(voxel);
+		if (voxel->instance != SRI_FREE) {
+			assert(voxel->instance == ride_index);
+			voxel->ClearInstances();
+		}
+	}
+}
+
+/**
  * Load a track piece.
  * @param rcd_file Data file being loaded.
  * @param sprites Already loaded sprite blocks.
@@ -301,6 +317,14 @@ bool PositionedTrackPiece::CanBeSuccessor(const PositionedTrackPiece &pred) cons
 {
 	if (pred.piece == nullptr) return false;
 	return this->CanBeSuccessor(pred.GetEndXYZ(), pred.piece->exit_connect);
+}
+
+/**
+ * Immediately remove this piece from all voxels it occupies.
+ * @param ride_index The index of the coaster that owns this piece.
+ */
+void PositionedTrackPiece::RemoveFromWorld(const uint16 ride_index) {
+	this->piece->RemoveFromWorld(ride_index, base_voxel);
 }
 
 void PositionedTrackPiece::Load(Loader &ldr)

--- a/src/track_piece.h
+++ b/src/track_piece.h
@@ -181,6 +181,8 @@ public:
 	TrackCurve *car_roll;     ///< Roll of cars over this track piece.
 	TrackCurve *car_yaw;      ///< Yaw of cars over this track piece, may be \c null.
 
+	void RemoveFromWorld(uint16 ride_index, XYZPoint16 base_voxel) const;
+
 	/**
 	 * Check whether the track piece is powered.
 	 * @return Whether the track piece enforces a non-zero speed.
@@ -277,6 +279,8 @@ public:
 	bool CanBePlaced() const;
 	bool CanBeSuccessor(const XYZPoint16 &vox, uint8 connect) const;
 	bool CanBeSuccessor(const PositionedTrackPiece &pred) const;
+
+	void RemoveFromWorld(uint16 ride_index);
 
 	/**
 	 * Get the position of the exit voxel.


### PR DESCRIPTION
This fixes a bug with deletion of rides. Steps to reproduce the issue in master:
- Go to Buy Ride, select something, click Select
- Place the shop or coaster
- Delete it by clicking Remove in its window and confirming
- Click Select in the Ride Selection window again → the previously deleted item becomes visible.