### PR TITLE
Shops Height

### DIFF
--- a/graphics/rcd/shops.txt
+++ b/graphics/rcd/shops.txt
@@ -14,7 +14,7 @@ file("shops.rcd") {
 	// Snack shop.
 	SHOP {
 		tile_width: 64;
-		height: 1;
+		height: 2;
 
 		(se, sw, nw, ne): spritefiles {
 			x_base: 0; y_base: 0;
@@ -36,7 +36,7 @@ file("shops.rcd") {
 	// Ice cream stall.
 	SHOP {
 		tile_width: 64;
-		height: 1;
+		height: 3;
 
 		(se, sw, nw, ne): spritefiles {
 			x_base: 0; y_base: 0;
@@ -69,7 +69,7 @@ file("shops.rcd") {
 	// Toilet.
 	SHOP {
 		tile_width: 64;
-		height: 1;
+		height: 2;
 
 		(se, sw, nw, ne): spritefiles {
 			x_base: 1; y_base: 0;

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -244,7 +244,7 @@ public:
 
 	void RemoveFromWorld() override;
 	void InsertIntoWorld() override {
-		// This was already done during construction – nothing left to do here
+		/* This was already done during construction – nothing left to do here. */
 	}
 
 	PositionedTrackPiece *pieces; ///< Positioned track pieces.

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -243,6 +243,9 @@ public:
 	void Save(Saver &svr);
 
 	void RemoveFromWorld() override;
+	void InsertIntoWorld() override {
+		// This was already done during construction – nothing left to do here
+	}
 
 	PositionedTrackPiece *pieces; ///< Positioned track pieces.
 	int capacity;                 ///< Number of entries in the #pieces.

--- a/src/ride_build.cpp
+++ b/src/ride_build.cpp
@@ -178,32 +178,25 @@ void RideBuildWindow::OnClick(WidgetNumber wid_num, const Point16 &pos)
  */
 bool RideBuildWindow::CanPlaceShop(const ShopType *selected_shop, const XYZPoint16 &pos, ViewOrientation vp_orient)
 {
-	// This function assumes that all shop have size 1×1.
+	// This function assumes that all shops have size 1×1.
 
 	/* 1. Can the position itself be used to build a shop? */
 	if (_world.GetTileOwner(pos.x, pos.y) != OWN_PARK) return false;
-	const Voxel *vx = _world.GetVoxel(pos);
-	if (vx != nullptr) {
+
+	auto check_if_location_is_suited = [&pos, selected_shop](const int8 offset, const bool need_flat_ground) {
+		const Voxel *vx = _world.GetVoxel(pos + XYZPoint16(0, 0, offset));
+		if (!vx || vx->GetGroundType() == GTP_INVALID || (need_flat_ground != (vx->GetGroundSlope() == SL_FLAT))) return false;
 		for (int8 h = selected_shop->height - 1; h >= 0; --h) {
-			const Voxel *v = _world.GetVoxel(pos + XYZPoint16(0, 0, h));
-			if (v && !v->CanPlaceInstance()) return false; // Cannot build on a path or other ride.
-		}
-
-		if (vx->GetGroundType() != GTP_INVALID && vx->GetGroundSlope() == SL_FLAT) return true; // Can build at a flat surface.
-	}
-
-	/* 2. Is the shop just above non-flat ground? */
-	if (pos.z > 0) {
-		vx = _world.GetVoxel(pos + XYZPoint16(0, 0, -1));
-
-		for (int8 h = selected_shop->height - 1; h >= 0; --h) {
-			const Voxel *v = _world.GetVoxel(pos + XYZPoint16(0, 0, h - 1));
+			const Voxel *v = _world.GetVoxel(pos + XYZPoint16(0, 0, h + offset));
 			if (v && !v->CanPlaceInstance()) return false;
 		}
+		return true;
+	};
 
-		if (vx != nullptr && vx->CanPlaceInstance() &&
-				vx->GetGroundType() != GTP_INVALID && vx->GetGroundSlope() != SL_FLAT) return true;
-	}
+	if (check_if_location_is_suited(0, true)) return true;
+
+	/* 2. Is the shop just above non-flat ground? */
+	if (pos.z > 0 && check_if_location_is_suited(-1, false)) return true;
 
 	/* 3. Is there a path at the right place? */
 	for (TileEdge entrance = EDGE_BEGIN; entrance < EDGE_COUNT; entrance++) { // Loop over the 4 unrotated directions.

--- a/src/ride_build.cpp
+++ b/src/ride_build.cpp
@@ -178,21 +178,19 @@ void RideBuildWindow::OnClick(WidgetNumber wid_num, const Point16 &pos)
  */
 bool RideBuildWindow::CanPlaceShop(const ShopType *selected_shop, const XYZPoint16 &pos, ViewOrientation vp_orient)
 {
-	// This function assumes that all shops have size 1×1.
+	/* This function assumes that all shops have size 1×1. */
 
 	/* 1. Can the position itself be used to build a shop? */
 	if (_world.GetTileOwner(pos.x, pos.y) != OWN_PARK) return false;
-
 	auto check_if_location_is_suited = [&pos, selected_shop](const int8 offset, const bool need_flat_ground) {
 		const Voxel *vx = _world.GetVoxel(pos + XYZPoint16(0, 0, offset));
-		if (!vx || vx->GetGroundType() == GTP_INVALID || (need_flat_ground != (vx->GetGroundSlope() == SL_FLAT))) return false;
+		if (vx == nullptr || vx->GetGroundType() == GTP_INVALID || (need_flat_ground != (vx->GetGroundSlope() == SL_FLAT))) return false;
 		for (int8 h = selected_shop->height - 1; h >= 0; --h) {
 			const Voxel *v = _world.GetVoxel(pos + XYZPoint16(0, 0, h + offset));
-			if (v && !v->CanPlaceInstance()) return false;
+			if (v != nullptr && !v->CanPlaceInstance()) return false;
 		}
 		return true;
 	};
-
 	if (check_if_location_is_suited(0, true)) return true;
 
 	/* 2. Is the shop just above non-flat ground? */

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -232,18 +232,6 @@ const RideType *RideInstance::GetRideType() const
  */
 
 /**
- * \fn void ShouldDrawPiece::InsertIntoWorld()
- * Whether the specified piece of the ride should be visible to the player.
- * @param voxel_number The instance data of the piece to check.
- * @return `false` if the ride piece is meant to be fully invisible; `true` otherwise.
- */
-bool RideInstance::ShouldDrawPiece(uint16 voxel_number) const
-{
-	// By default, all pieces are drawn, unless a subclass implements a special case
-	return true;
-}
-
-/**
  * Can the ride be visited, assuming it is approached from direction \a edge?
  * @param vox Position of the voxel with the ride.
  * @param edge Direction of movement (exit direction of the neighbouring voxel).
@@ -647,7 +635,6 @@ void RidesManager::NewInstanceAdded(uint16 num)
 	RideInstance *ri = this->GetRideInstance(num);
 	const RideType *rt = ri->GetRideType();
 	assert(ri->state == RIS_ALLOCATED);
-
 	ri->InsertIntoWorld();
 
 	/* Find a new name for the instance. */

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -227,6 +227,23 @@ const RideType *RideInstance::GetRideType() const
  */
 
 /**
+ * \fn void RideInstance::InsertIntoWorld()
+ * Ensure that this shop is linked into the voxels it is meant to occupy.
+ */
+
+/**
+ * \fn void ShouldDrawPiece::InsertIntoWorld()
+ * Whether the specified piece of the ride should be visible to the player.
+ * @param voxel_number The instance data of the piece to check.
+ * @return `false` if the ride piece is meant to be fully invisible; `true` otherwise.
+ */
+bool RideInstance::ShouldDrawPiece(uint16 voxel_number) const
+{
+	// By default, all pieces are drawn, unless a subclass implements a special case
+	return true;
+}
+
+/**
  * Can the ride be visited, assuming it is approached from direction \a edge?
  * @param vox Position of the voxel with the ride.
  * @param edge Direction of movement (exit direction of the neighbouring voxel).
@@ -630,6 +647,8 @@ void RidesManager::NewInstanceAdded(uint16 num)
 	RideInstance *ri = this->GetRideInstance(num);
 	const RideType *rt = ri->GetRideType();
 	assert(ri->state == RIS_ALLOCATED);
+
+	ri->InsertIntoWorld();
 
 	/* Find a new name for the instance. */
 	const StringID *names = rt->GetInstanceNames();

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -136,11 +136,13 @@ public:
 	virtual ~RideInstance();
 
 	virtual void GetSprites(uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const = 0;
+	virtual bool ShouldDrawPiece(uint16 voxel_number) const;
 	virtual uint8 GetEntranceDirections(const XYZPoint16 &vox) const = 0;
 	virtual RideEntryResult EnterRide(int guest, TileEdge entry_edge) = 0;
 	virtual XYZPoint32 GetExit(int guest, TileEdge entry_edge) = 0;
 	virtual void RemoveAllPeople() = 0;
 	virtual void RemoveFromWorld() = 0;
+	virtual void InsertIntoWorld() = 0;
 	bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const;
 
 	void SellItem(int item_index);

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -46,6 +46,7 @@ enum ShopFlags {
 	SHF_NW_ENTRANCE = 1 << EDGE_NW, ///< Entrance in NW direction (unrotated).
 
 	SHF_ENTRANCE_BITS = (SHF_NE_ENTRANCE | SHF_SE_ENTRANCE | SHF_SW_ENTRANCE | SHF_NW_ENTRANCE), ///< Bit mask for the entrances.
+	SHF_ENTRANCE_NONE = 0, ///< Shop tile without entrances (used for upper storeys of buildings)
 };
 
 /** Type of items that can be bought. */

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -136,7 +136,6 @@ public:
 	virtual ~RideInstance();
 
 	virtual void GetSprites(uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const = 0;
-	virtual bool ShouldDrawPiece(uint16 voxel_number) const;
 	virtual uint8 GetEntranceDirections(const XYZPoint16 &vox) const = 0;
 	virtual RideEntryResult EnterRide(int guest, TileEdge entry_edge) = 0;
 	virtual XYZPoint32 GetExit(int guest, TileEdge entry_edge) = 0;

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -46,7 +46,7 @@ enum ShopFlags {
 	SHF_NW_ENTRANCE = 1 << EDGE_NW, ///< Entrance in NW direction (unrotated).
 
 	SHF_ENTRANCE_BITS = (SHF_NE_ENTRANCE | SHF_SE_ENTRANCE | SHF_SW_ENTRANCE | SHF_NW_ENTRANCE), ///< Bit mask for the entrances.
-	SHF_ENTRANCE_NONE = 0, ///< Shop tile without entrances (used for upper storeys of buildings)
+	SHF_ENTRANCE_NONE = 0, ///< Shop tile without entrances (used for upper storeys of buildings).
 };
 
 /** Type of items that can be bought. */

--- a/src/shop_type.cpp
+++ b/src/shop_type.cpp
@@ -160,15 +160,10 @@ const ShopType *ShopInstance::GetShopType() const
 	return static_cast<const ShopType *>(this->type);
 }
 
-bool ShopInstance::ShouldDrawPiece(const uint16 voxel_number) const
-{
-	return voxel_number != INVISIBLE_SHOP_TILE && RideInstance::ShouldDrawPiece(voxel_number);
-}
-
 void ShopInstance::GetSprites(uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const
 {
 	sprites[0] = nullptr;
-	sprites[1] = this->type->GetView((4 + this->orientation - orient) & 3);
+	sprites[1] = voxel_number == INVISIBLE_SHOP_TILE ? nullptr : this->type->GetView((4 + this->orientation - orient) & 3);
 	sprites[2] = nullptr;
 	sprites[3] = nullptr;
 }
@@ -302,6 +297,7 @@ void ShopInstance::Load(Loader &ldr)
 
 	SmallRideInstance inst_number = static_cast<SmallRideInstance>(this->GetIndex());
 	uint8 entrances = this->GetEntranceDirections(this->vox_pos);
+	AddRemovePathEdges(this->vox_pos, PATH_EMPTY, entrances, PAS_QUEUE_PATH);
 
 	const int16 height = this->GetShopType()->height;
 	for (int16 i = 0; i < height; ++i) {
@@ -309,8 +305,6 @@ void ShopInstance::Load(Loader &ldr)
 		if (v != nullptr && v->GetInstance() == SRI_FREE) {
 			v->SetInstance(inst_number);
 			v->SetInstanceData(i > 0 ? INVISIBLE_SHOP_TILE : entrances);
-
-			AddRemovePathEdges(this->vox_pos, PATH_EMPTY, entrances, PAS_QUEUE_PATH);
 		} else {
 			ldr.SetFailMessage("Invalid world coordinates for shop.");
 			return;

--- a/src/shop_type.cpp
+++ b/src/shop_type.cpp
@@ -19,8 +19,6 @@
 static const int TOILET_TIME = 5000;  ///< Duration of visiting the toilet.
 static const int CAPACITY_TOILET = 2; ///< Maximum number of guests that can use the toilet at the same time.
 
-static const int INVISIBLE_SHOP_TILE = 255; ///< Voxel instance data value to indicate that the shop piece should not be rendered
-
 ShopType::ShopType() : RideType(RTK_SHOP)
 {
 	this->height = 0;
@@ -163,7 +161,7 @@ const ShopType *ShopInstance::GetShopType() const
 void ShopInstance::GetSprites(uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const
 {
 	sprites[0] = nullptr;
-	sprites[1] = voxel_number == INVISIBLE_SHOP_TILE ? nullptr : this->type->GetView((4 + this->orientation - orient) & 3);
+	sprites[1] = voxel_number == SHF_ENTRANCE_NONE ? nullptr : this->type->GetView((4 + this->orientation - orient) & 3);
 	sprites[2] = nullptr;
 	sprites[3] = nullptr;
 }
@@ -245,7 +243,7 @@ void ShopInstance::InsertIntoWorld()
 		Voxel *voxel = _world.GetCreateVoxel(this->vox_pos + XYZPoint16(0, 0, i), true);
 		assert(voxel && voxel->GetInstance() == SRI_FREE);
 		voxel->SetInstance(index);
-		voxel->SetInstanceData(i > 0 ? INVISIBLE_SHOP_TILE : entrances);
+		voxel->SetInstanceData(i > 0 ? SHF_ENTRANCE_NONE : entrances);
 	}
 }
 
@@ -304,7 +302,7 @@ void ShopInstance::Load(Loader &ldr)
 		Voxel *v = _world.GetCreateVoxel(this->vox_pos + XYZPoint16(0, 0, i), true);
 		if (v != nullptr && v->GetInstance() == SRI_FREE) {
 			v->SetInstance(inst_number);
-			v->SetInstanceData(i > 0 ? INVISIBLE_SHOP_TILE : entrances);
+			v->SetInstanceData(i > 0 ? SHF_ENTRANCE_NONE : entrances);
 		} else {
 			ldr.SetFailMessage("Invalid world coordinates for shop.");
 			return;

--- a/src/shop_type.h
+++ b/src/shop_type.h
@@ -44,7 +44,6 @@ public:
 
 	const ShopType *GetShopType() const;
 	void GetSprites(uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const override;
-	bool ShouldDrawPiece(uint16 voxel_number) const override;
 
 	void SetRide(uint8 orientation, const XYZPoint16 &pos);
 	uint8 GetEntranceDirections(const XYZPoint16 &vox) const override;

--- a/src/shop_type.h
+++ b/src/shop_type.h
@@ -44,6 +44,7 @@ public:
 
 	const ShopType *GetShopType() const;
 	void GetSprites(uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const override;
+	bool ShouldDrawPiece(uint16 voxel_number) const override;
 
 	void SetRide(uint8 orientation, const XYZPoint16 &pos);
 	uint8 GetEntranceDirections(const XYZPoint16 &vox) const override;
@@ -55,6 +56,7 @@ public:
 	void Load(Loader &ldr) override;
 	void Save(Saver &svr) override;
 
+	void InsertIntoWorld() override;
 	void RemoveFromWorld() override;
 
 	uint8 orientation;  ///< Orientation of the shop.

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -451,9 +451,9 @@ void SpriteCollector::SetupSupports(const VoxelStack *stack, uint xpos, uint ypo
 static int DrawRide(int32 slice, int zpos, const Point32 base_pos, ViewOrientation orient, uint16 number, uint16 voxel_number, DrawData *dd, uint8 *platform)
 {
 	const RideInstance *ri = _rides_manager.GetRideInstance(number);
-	if (ri == nullptr || !ri->ShouldDrawPiece(voxel_number)) return 0;
+	if (ri == nullptr) return 0;
 	/* Shops are connected in every direction. */
-	if (platform != nullptr) *platform = (ri->GetKind() == RTK_SHOP) ? PATH_NE_NW_SE_SW : PATH_INVALID;
+	if (platform != nullptr) *platform = (ri->GetKind() == RTK_SHOP && zpos == static_cast<const ShopInstance*>(ri)->vox_pos.z) ? PATH_NE_NW_SE_SW : PATH_INVALID;
 
 	const ImageData *sprites[4];
 	ri->GetSprites(voxel_number, orient, sprites);

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -451,7 +451,7 @@ void SpriteCollector::SetupSupports(const VoxelStack *stack, uint xpos, uint ypo
 static int DrawRide(int32 slice, int zpos, const Point32 base_pos, ViewOrientation orient, uint16 number, uint16 voxel_number, DrawData *dd, uint8 *platform)
 {
 	const RideInstance *ri = _rides_manager.GetRideInstance(number);
-	if (ri == nullptr) return 0;
+	if (ri == nullptr || !ri->ShouldDrawPiece(voxel_number)) return 0;
 	/* Shops are connected in every direction. */
 	if (platform != nullptr) *platform = (ri->GetKind() == RTK_SHOP) ? PATH_NE_NW_SE_SW : PATH_INVALID;
 


### PR DESCRIPTION
Previously all shops had a height of 1, allowing players to build paths directly above them. Now any height is supported, and the default shops are given heights of 2 (snacks, toilet) or 3 (ice) to ensure they get sufficient vertical space.