### PR TITLE
Fix assert fail when closing Ride Selection window

### DIFF
--- a/src/ride_gui.cpp
+++ b/src/ride_gui.cpp
@@ -129,10 +129,7 @@ RideSelectGui::RideSelectGui() : GuiWindow(WC_RIDE_SELECT, ALL_WINDOWS_OF_TYPE)
 	this->SetNewRideKind(this->current_kind, true);
 }
 
-RideSelectGui::~RideSelectGui()
-{
-	_rides_manager.CheckNoAllocatedRides(); // Check that no rides are being constructed.
-}
+RideSelectGui::~RideSelectGui() = default;
 
 void RideSelectGui::UpdateWidgetSize(WidgetNumber wid_num, BaseWidget *wid)
 {
@@ -244,6 +241,7 @@ void RideSelectGui::OnClick(WidgetNumber wid_num, const Point16 &pos)
 					_rides_manager.NewInstanceAdded(instance);
 					ShowCoasterManagementGui(ri);
 				}
+				delete this;
 			}
 			break;
 		}

--- a/src/ride_gui.cpp
+++ b/src/ride_gui.cpp
@@ -26,7 +26,7 @@
 class RideSelectGui : public GuiWindow {
 public:
 	RideSelectGui();
-	~RideSelectGui();
+	~RideSelectGui() = default;
 
 	void UpdateWidgetSize(WidgetNumber wid_num, BaseWidget *wid) override;
 	void DrawWidget(WidgetNumber wid_num, const BaseWidget *wid) const override;
@@ -128,8 +128,6 @@ RideSelectGui::RideSelectGui() : GuiWindow(WC_RIDE_SELECT, ALL_WINDOWS_OF_TYPE)
 	}
 	this->SetNewRideKind(this->current_kind, true);
 }
-
-RideSelectGui::~RideSelectGui() = default;
 
 void RideSelectGui::UpdateWidgetSize(WidgetNumber wid_num, BaseWidget *wid)
 {

--- a/src/ride_gui.cpp
+++ b/src/ride_gui.cpp
@@ -26,7 +26,6 @@
 class RideSelectGui : public GuiWindow {
 public:
 	RideSelectGui();
-	~RideSelectGui() = default;
 
 	void UpdateWidgetSize(WidgetNumber wid_num, BaseWidget *wid) override;
 	void DrawWidget(WidgetNumber wid_num, const BaseWidget *wid) const override;
@@ -239,7 +238,6 @@ void RideSelectGui::OnClick(WidgetNumber wid_num, const Point16 &pos)
 					_rides_manager.NewInstanceAdded(instance);
 					ShowCoasterManagementGui(ri);
 				}
-				delete this;
 			}
 			break;
 		}

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -710,17 +710,6 @@ void RidesManager::DeleteAllRideInstances()
 }
 
 /**
- * Check that no rides are under construction at the moment of calling.
- * @note This is just a checking function, perhaps eventually remove it?
- */
-void RidesManager::CheckNoAllocatedRides() const
-{
-	for (uint i = 0; i < lengthof(this->instances); i++) {
-		assert(this->instances[i] == nullptr || this->instances[i]->state != RIS_ALLOCATED);
-	}
-}
-
-/**
  * Does a ride entrance exists at/to the bottom the given voxel in the neighbouring voxel?
  * @param pos Coordinate of the voxel.
  * @param edge Direction to move to get the neighbouring voxel.

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -202,7 +202,6 @@ public:
 	void NewInstanceAdded(uint16 num);
 	void DeleteInstance(uint16 num);
 	void DeleteAllRideInstances();
-	void CheckNoAllocatedRides() const;
 
 	void OnAnimate(int delay);
 	void OnNewMonth();


### PR DESCRIPTION
The bug can be reproduced in master by opening the Ride Selection window, choosing a shop, clicking Select, and then closing the Ride Selection window while the Place Shop window is still open.

I wondered whether the assert might be guarding against a possible memory leak or heap-use-after-free, so I compiled&linked with ASan and it turns out that this is not the case, so it can safely be removed.