### PR TITLE
Implement queuing behaviour for guests

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -335,16 +335,28 @@ public:
 
 	/**
 	 * Merge voxel coordinate, #vox_pos, with in-voxel coordinate, #pix_pos.
+	 * @param vox_pos Coordinates of the voxel in the world.
+	 * @param pix_pos Pixel position inside the voxel.
 	 * @return Merged coordinates as 32 bit 3D point. Lower 8 bits are the in-voxel coordinate; upper remaining bits are the voxel coordinate.
 	 * @see GetVoxelCoordinate, GetInVoxelCoordinate
 	 */
-	inline XYZPoint32 MergeCoordinates()
+	static inline XYZPoint32 MergeCoordinates(const XYZPoint16& vox_pos, const XYZPoint16& pix_pos)
 	{
-		uint32 x = (static_cast<uint32>(this->vox_pos.x) << 8) | (this->pix_pos.x & 0xff);
-		uint32 y = (static_cast<uint32>(this->vox_pos.y) << 8) | (this->pix_pos.y & 0xff);
-		uint32 z = (static_cast<uint32>(this->vox_pos.z) << 8) | (this->pix_pos.z & 0xff);
+		uint32 x = (static_cast<uint32>(vox_pos.x) << 8) | (pix_pos.x & 0xff);
+		uint32 y = (static_cast<uint32>(vox_pos.y) << 8) | (pix_pos.y & 0xff);
+		uint32 z = (static_cast<uint32>(vox_pos.z) << 8) | (pix_pos.z & 0xff);
 
 		return XYZPoint32(x, y, z);
+	}
+
+	/**
+	 * Merge voxel coordinate, #vox_pos, with in-voxel coordinate, #pix_pos.
+	 * @return Merged coordinates as 32 bit 3D point. Lower 8 bits are the in-voxel coordinate; upper remaining bits are the voxel coordinate.
+	 * @see GetVoxelCoordinate, GetInVoxelCoordinate
+	 */
+	inline XYZPoint32 MergeCoordinates() const
+	{
+		return MergeCoordinates(this->vox_pos, this->pix_pos);
 	}
 
 	/**

--- a/src/person.h
+++ b/src/person.h
@@ -127,6 +127,13 @@ public:
 		return this->type == PERSON_GUEST;
 	}
 
+	/**
+	 * Test whether this person is a guest queuing for a ride.
+	 * @return Whether the person is a guest and queuing.
+	 */
+	bool IsQueuingGuest() const;
+	bool IsQueuingGuestNearby(const XYZPoint16& vox_pos, const XYZPoint16& pix_pos, bool only_in_front);
+
 	void SetName(const uint8 *name);
 	const uint8 *GetName() const;
 

--- a/src/person.h
+++ b/src/person.h
@@ -127,10 +127,6 @@ public:
 		return this->type == PERSON_GUEST;
 	}
 
-	/**
-	 * Test whether this person is a guest queuing for a ride.
-	 * @return Whether the person is a guest and queuing.
-	 */
 	bool IsQueuingGuest() const;
 	bool IsQueuingGuestNearby(const XYZPoint16& vox_pos, const XYZPoint16& pix_pos, bool only_in_front);
 


### PR DESCRIPTION
Let guests line up in a neat queue line when waiting for a ride. A queue path can hold approximately 4 guests per tile. Guests will refuse to enter a queue if the queue line is completely filled. For rides where the entrance is directly at a normal path, at most 1 guest can queue.

![grafik](https://user-images.githubusercontent.com/48293446/107643594-a4196300-6c76-11eb-9886-2b9e1350886c.png)
