### PR TITLE
Don't draw path edges around rides

### DIFF
--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -688,6 +688,11 @@ XYZPoint32 CoasterInstance::GetExit(int guest, TileEdge entry_edge)
 	return XYZPoint32(); // Suppress compiler warning
 }
 
+bool CoasterInstance::PathEdgeWanted(const XYZPoint16 &vox, const TileEdge edge) const
+{
+	return false;  // \todo Check whether there is an entrance or exit here.
+}
+
 void CoasterInstance::RemoveAllPeople()
 {
 	/** \todo Implement when allowing people on the ride. */

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -215,6 +215,7 @@ public:
 	XYZPoint32 GetExit(int guest, TileEdge entry_edge) override;
 	void RemoveAllPeople() override;
 	bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const override;
+	bool PathEdgeWanted(const XYZPoint16 &vox, TileEdge edge) const override;
 
 	RideInstanceState DecideRideState();
 

--- a/src/fixed_ride_type.cpp
+++ b/src/fixed_ride_type.cpp
@@ -169,7 +169,7 @@ void FixedRideInstance::GetSprites(const XYZPoint16 &vox, uint16 voxel_number, u
 		const ImageData *const *array = _rides_manager.exits[this->exit_type]->images[orientation_index(EntranceExitRotation(vox))];
 		sprites[1] = array[0];
 		sprites[2] = array[1];
-	} else if (voxel_number == SHF_ENTRANCE_NONE) {
+	} else if (vox.z != this->vox_pos.z) {
 		sprites[1] = nullptr;
 	} else {
 		const FrameSet *set_to_use;
@@ -255,10 +255,11 @@ void FixedRideInstance::InsertIntoWorld()
 			const int8 height = this->GetFixedRideType()->GetHeight(x, y);
 			const XYZPoint16 location = FixedRideType::OrientatedOffset(this->orientation, x, y);
 			for (int16 h = 0; h < height; ++h) {
-				Voxel *voxel = _world.GetCreateVoxel(this->vox_pos + XYZPoint16(location.x, location.y, h), true);
+				const XYZPoint16 p = this->vox_pos + XYZPoint16(location.x, location.y, h);
+				Voxel *voxel = _world.GetCreateVoxel(p, true);
 				assert(voxel && voxel->GetInstance() == SRI_FREE);
 				voxel->SetInstance(index);
-				voxel->SetInstanceData(h == 0 ? SHF_ENTRANCE_BITS : SHF_ENTRANCE_NONE);
+				voxel->SetInstanceData(h == 0 ? GetEntranceDirections(p) : SHF_ENTRANCE_NONE);
 			}
 		}
 	}

--- a/src/gentle_thrill_ride_type.cpp
+++ b/src/gentle_thrill_ride_type.cpp
@@ -167,7 +167,7 @@ const Recolouring *GentleThrillRideInstance::GetRecolours(const XYZPoint16 &pos)
 
 uint8 GentleThrillRideInstance::GetEntranceDirections(const XYZPoint16 &vox) const
 {
-	return SHF_ENTRANCE_BITS;  // Used for rendering of platforms only.
+	return (vox == this->entrance_pos || vox == this->exit_pos) ? 1 << EntranceExitRotation(vox) : SHF_ENTRANCE_NONE;
 }
 
 RideEntryResult GentleThrillRideInstance::EnterRide(int guest, TileEdge entry)
@@ -266,13 +266,20 @@ void GentleThrillRideInstance::SetEntrancePos(const XYZPoint16& pos)
 
 	this->entrance_pos = pos;
 	if (this->entrance_pos != XYZPoint16::invalid()) {
+		int edges = 0;
 		for (int16 h = 0; h < height; ++h) {
-			Voxel *voxel = _world.GetCreateVoxel(this->entrance_pos + XYZPoint16(0, 0, h), true);
+			const XYZPoint16 p = this->entrance_pos + XYZPoint16(0, 0, h);
+			Voxel *voxel = _world.GetCreateVoxel(p, true);
 			assert(voxel != nullptr && voxel->instance == SRI_FREE);
 			voxel->SetInstance(index);
-			voxel->SetInstanceData(h == 0 ? SHF_ENTRANCE_BITS : SHF_ENTRANCE_NONE);
+			if (h == 0) {
+				edges = GetEntranceDirections(p);
+				voxel->SetInstanceData(edges);
+			} else {
+				voxel->SetInstanceData(SHF_ENTRANCE_NONE);
+			}
 		}
-		AddRemovePathEdges(this->entrance_pos, PATH_EMPTY, EDGE_ALL, PAS_QUEUE_PATH);
+		AddRemovePathEdges(this->entrance_pos, PATH_EMPTY, edges, PAS_QUEUE_PATH);
 	}
 }
 
@@ -297,13 +304,20 @@ void GentleThrillRideInstance::SetExitPos(const XYZPoint16& pos)
 
 	this->exit_pos = pos;
 		if (this->exit_pos != XYZPoint16::invalid()) {
+		int edges = 0;
 		for (int16 h = 0; h < height; ++h) {
-			Voxel *voxel = _world.GetCreateVoxel(this->exit_pos + XYZPoint16(0, 0, h), true);
+			const XYZPoint16 p = this->exit_pos + XYZPoint16(0, 0, h);
+			Voxel *voxel = _world.GetCreateVoxel(p, true);
 			assert(voxel != nullptr && voxel->instance == SRI_FREE);
 			voxel->SetInstance(index);
-			voxel->SetInstanceData(h == 0 ? SHF_ENTRANCE_BITS : SHF_ENTRANCE_NONE);
+			if (h == 0) {
+				edges = GetEntranceDirections(p);
+				voxel->SetInstanceData(edges);
+			} else {
+				voxel->SetInstanceData(SHF_ENTRANCE_NONE);
+			}
 		}
-		AddRemovePathEdges(this->exit_pos, PATH_EMPTY, EDGE_ALL, PAS_NORMAL_PATH);
+		AddRemovePathEdges(this->exit_pos, PATH_EMPTY, edges, PAS_NORMAL_PATH);
 	}
 }
 

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -10,6 +10,7 @@
 #include "stdafx.h"
 #include "path.h"
 #include "map.h"
+#include "ride_type.h"
 #include "viewport.h"
 
 /** Imploded path tile sprite number to use for an 'up' slope from a given edge. */
@@ -418,7 +419,7 @@ static bool ExamineNeighbourPathEdge(const XYZPoint16 &voxel_pos, TileEdge edge,
 		return true;
 
 	} else if (number >= SRI_FULL_RIDES) { // A ride instance. Does it have an entrance here?
-		if ((v->GetInstanceData() & (1 << edge)) != 0) {
+		if (_rides_manager.GetRideInstance(number)->PathEdgeWanted(voxel_pos, edge)) {
 			*dest_status = PAS_QUEUE_PATH;
 			return true;
 		}

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -385,6 +385,17 @@ void RideInstance::SetExitType(const int type)
 }
 
 /**
+ * Whether a path edge to/from this ride should be drawn at the given location.
+ * @param vox Coordinates in the world.
+ * @param edge Tile edge to check.
+ * @return A path edge should be added.
+ */
+bool RideInstance::PathEdgeWanted(const XYZPoint16 &vox, const TileEdge edge) const
+{
+	return (_world.GetVoxel(vox)->GetInstanceData() & (1 << edge)) != 0;
+}
+
+/**
  * Some time has passed, update the state of the ride. Default implementation does nothing.
  * @param delay Number of milliseconds that passed.
  */

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -168,6 +168,7 @@ public:
 	virtual void RemoveFromWorld() = 0;
 	virtual void InsertIntoWorld() = 0;
 	virtual bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const = 0;
+	virtual bool PathEdgeWanted(const XYZPoint16 &vox, TileEdge edge) const;
 
 	void SellItem(int item_index);
 	ItemType GetSaleItemType(int item_index) const;


### PR DESCRIPTION
Fixes the drawing of path edges around rides. Now path edges are added only to the main edge of entrances and exits, and to the front side of shops.

Before:
![grafik](https://user-images.githubusercontent.com/48293446/107982866-1666ac00-6fc5-11eb-8d26-854695efed56.png)

After:
![grafik](https://user-images.githubusercontent.com/48293446/107982787-f46d2980-6fc4-11eb-8fad-24313128c9f2.png)
