### PR TITLE
Implement entrances and exits for coasters

### DIFF
--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -654,7 +654,7 @@ void CoasterInstance::CloseRide()
 	RideInstance::CloseRide();
 }
 
-void CoasterInstance::GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const
+void CoasterInstance::GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const
 {
 	const CoasterType *ct = this->GetCoasterType();
 
@@ -667,12 +667,14 @@ void CoasterInstance::GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uin
 		const ImageData *const *array = _rides_manager.entrances[this->entrance_type]->images[orientation_index(EntranceExitRotation(vox, nullptr))];
 		sprites[1] = array[0];
 		sprites[2] = array[1];
+		if (platform != nullptr) *platform = PATH_NE_NW_SE_SW;
 		return;
 	}
 	if (this->IsExitLocation(vox)) {
 		const ImageData *const *array = _rides_manager.exits[this->exit_type]->images[orientation_index(EntranceExitRotation(vox, nullptr))];
 		sprites[1] = array[0];
 		sprites[2] = array[1];
+		if (platform != nullptr) *platform = PATH_NE_NW_SE_SW;
 		return;
 	}
 	if (voxel_number == ENTRANCE_OR_EXIT) {

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -219,7 +219,7 @@ public:
 
 	void TestRide();
 
-	void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const override;
+	void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const override;
 	uint8 GetEntranceDirections(const XYZPoint16 &vox) const override;
 	RideEntryResult EnterRide(int guest, TileEdge entry) override;
 	XYZPoint32 GetExit(int guest, TileEdge entry_edge) override;

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -183,6 +183,16 @@ public:
 	const PositionedTrackPiece *cur_piece; ///< Track piece that has the back-end position of the train.
 };
 
+/** A station belonging to a coaster. */
+struct CoasterStation {
+	CoasterStation();
+
+	std::vector<XYZPoint16> locations;  ///< Voxels occupied by the station.
+	TileEdge direction;                 ///< The start direction of the station's first tile.
+	XYZPoint16 entrance;                ///< Position of the station's entrance (may be \c invalid()).
+	XYZPoint16 exit;                    ///< Position of the station's exit (may be \c invalid()).
+};
+
 /**
  * A roller coaster in the world.
  * Since roller coaster rides need to be constructed by the user first, an instance can exist
@@ -214,8 +224,10 @@ public:
 	RideEntryResult EnterRide(int guest, TileEdge entry) override;
 	XYZPoint32 GetExit(int guest, TileEdge entry_edge) override;
 	void RemoveAllPeople() override;
+	bool CanOpenRide() const override;
 	bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const override;
 	bool PathEdgeWanted(const XYZPoint16 &vox, TileEdge edge) const override;
+	const Recolouring *GetRecolours(const XYZPoint16 &pos) const override;
 
 	RideInstanceState DecideRideState();
 
@@ -227,6 +239,14 @@ public:
 	int FindSuccessorPiece(const XYZPoint16 &vox, uint8 entry_connect, int start = 0, int end = MAX_PLACED_TRACK_PIECES);
 	int FindSuccessorPiece(const PositionedTrackPiece &placed);
 	int FindPredecessorPiece(const PositionedTrackPiece &placed);
+	void UpdateStations();
+	bool CanPlaceEntranceOrExit(const XYZPoint16 &pos, bool entrance, const CoasterStation *station) const;
+	bool PlaceEntranceOrExit(const XYZPoint16 &pos, bool entrance, CoasterStation *station);
+	bool NeedsEntrance() const;
+	bool NeedsExit() const;
+	bool IsEntranceLocation(const XYZPoint16& pos) const override;
+	bool IsExitLocation(const XYZPoint16& pos) const override;
+	int EntranceExitRotation(const XYZPoint16& vox, const CoasterStation *station) const;
 
 	SmallRideInstance GetRideNumber() const;
 	uint16 GetInstanceData(const TrackVoxel *tv) const;
@@ -244,6 +264,8 @@ public:
 	void Load(Loader &ldr);
 	void Save(Saver &svr);
 
+	void RemoveStationsFromWorld();
+	void InsertStationsIntoWorld();
 	void RemoveFromWorld() override;
 	void InsertIntoWorld() override {
 		/* This was already done during construction – nothing left to do here. */
@@ -254,6 +276,9 @@ public:
 	uint32 coaster_length;        ///< Total length of the roller coaster track (in 1/256 pixels).
 	CoasterTrain trains[4];       ///< Trains at the roller coaster (with an arbitrary max size). A train without cars means the train is not used.
 	const CarType *car_type;      ///< Type of cars running at the coaster.
+	std::vector<CoasterStation> stations;  ///< All stations of this coaster.
+	XYZPoint16 temp_entrance_pos;          ///< Temporary location of one of the ride's entrance while the user is moving the entrance.
+	XYZPoint16 temp_exit_pos;              ///< Temporary location of one of the ride's exit while the user is moving the exit.
 };
 
 bool LoadCoasterPlatform(RcdFileReader *rcdfile, const ImageMap &sprites);

--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -185,16 +185,16 @@ CoasterInstanceWindow::~CoasterInstanceWindow()
 	}
 }
 
-assert_compile(MAX_RECOLOUR >= 3); ///< Check that the 3 recolourings of a gentle/thrill ride fit in the Recolouring::entries array.
+assert_compile(MAX_RECOLOUR >= MAX_RIDE_RECOLOURS); ///< Check that the 3 recolourings of a gentle/thrill ride fit in the Recolouring::entries array.
 
 /** Update all recolour buttons of the window. */
 void CoasterInstanceWindow::UpdateRecolourButtons()
 {
-	for (int i = 0; i < 3; i++) {
+	for (int i = 0; i < MAX_RIDE_RECOLOURS; i++) {
 		const RecolourEntry &re = this->ci->entrance_recolours.entries[i];
 		this->GetWidget<LeafWidget>(CIW_ENTRANCE_RECOLOUR1 + i)->SetShaded(!re.IsValid());
 	}
-	for (int i = 0; i < 3; i++) {
+	for (int i = 0; i < MAX_RIDE_RECOLOURS; i++) {
 		const RecolourEntry &re = this->ci->exit_recolours.entries[i];
 		this->GetWidget<LeafWidget>(CIW_EXIT_RECOLOUR1 + i)->SetShaded(!re.IsValid());
 	}
@@ -378,15 +378,8 @@ void CoasterInstanceWindow::OnChange(const ChangeCode code, const uint32 paramet
 void CoasterInstanceWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
 {
 	const Point32 world_pos = vp->ComputeHorizontalTranslation(vp->rect.width / 2 - pos.x, vp->rect.height / 2 - pos.y);
-	int dx, dy;
-	switch (vp->orientation) {
-		case VOR_NORTH: dx =  1; dy =  1; break;
-		case VOR_WEST:  dx = -1; dy =  1; break;
-		case VOR_SOUTH: dx = -1; dy = -1; break;
-		case VOR_EAST:  dx =  1; dy = -1; break;
-		default: NOT_REACHED();
-	}
-
+	const int8 dx = _orientation_signum_dx[vp->orientation];
+	const int8 dy = _orientation_signum_dy[vp->orientation];
 	entrance_exit_placement.MarkDirty();
 	bool placed = false;
 	for (int z = WORLD_Z_SIZE - 1; z >= 0; z--) {

--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -67,12 +67,22 @@ void ShowCoasterRemove(CoasterInstance *ci)
 
 /** Widget numbers of the roller coaster instance window. */
 enum CoasterInstanceWidgets {
-	CIW_TITLEBAR, ///< Titlebar widget.
-	CIW_REMOVE,   ///< Remove button widget.
-	CIW_EDIT,     ///< Edit coaster widget.
-	CIW_CLOSE,    ///< Close coaster widget
-	CIW_TEST,     ///< Test coaster widget
-	CIW_OPEN,     ///< Open coaster widget
+	CIW_TITLEBAR,            ///< Titlebar widget.
+	CIW_REMOVE,              ///< Remove button widget.
+	CIW_EDIT,                ///< Edit coaster widget.
+	CIW_CLOSE,               ///< Close coaster widget
+	CIW_TEST,                ///< Test coaster widget
+	CIW_OPEN,                ///< Open coaster widget
+	CIW_PLACE_ENTRANCE,      ///< Entrance placement.
+	CIW_CHOOSE_ENTRANCE,     ///< Entrance style.
+	CIW_PLACE_EXIT,          ///< Exit placement.
+	CIW_CHOOSE_EXIT,         ///< Exit style.
+	CIW_ENTRANCE_RECOLOUR1,  ///< First entrance colour.
+	CIW_ENTRANCE_RECOLOUR2,  ///< Second entrance colour.
+	CIW_ENTRANCE_RECOLOUR3,  ///< Third entrance colour.
+	CIW_EXIT_RECOLOUR1,      ///< First exit colour.
+	CIW_EXIT_RECOLOUR2,      ///< Second exit colour.
+	CIW_EXIT_RECOLOUR3,      ///< Third exit colour.
 };
 
 /** Widget parts of the #CoasterInstanceWindow. */
@@ -96,6 +106,27 @@ static const WidgetPart _coaster_instance_gui_parts[] = {
 			EndContainer(),
 		EndContainer(),
 
+		Widget(WT_PANEL, INVALID_WIDGET_INDEX, COL_RANGE_DARK_RED),
+			Intermediate(3, 2),
+				Widget(WT_TEXT_PUSHBUTTON, CIW_PLACE_ENTRANCE, COL_RANGE_DARK_RED),
+						SetData(GUI_PLACE_ENTRANCE, GUI_PLACE_ENTRANCE_TOOLTIP),
+				Widget(WT_TEXT_PUSHBUTTON, CIW_PLACE_EXIT, COL_RANGE_DARK_RED),
+						SetData(GUI_PLACE_EXIT, GUI_PLACE_EXIT_TOOLTIP),
+				Widget(WT_DROPDOWN_BUTTON, CIW_CHOOSE_ENTRANCE, COL_RANGE_DARK_RED),
+						SetData(GUI_CHOOSE_ENTRANCE, GUI_CHOOSE_ENTRANCE_TOOLTIP),
+				Widget(WT_DROPDOWN_BUTTON, CIW_CHOOSE_EXIT, COL_RANGE_DARK_RED),
+						SetData(GUI_CHOOSE_EXIT, GUI_CHOOSE_EXIT_TOOLTIP),
+				Intermediate(1, 3),
+					Widget(WT_DROPDOWN_BUTTON, CIW_ENTRANCE_RECOLOUR1, COL_RANGE_DARK_RED), SetData(STR_ARG1, STR_NULL), SetPadding(2, 2, 2, 2),
+					Widget(WT_DROPDOWN_BUTTON, CIW_ENTRANCE_RECOLOUR2, COL_RANGE_DARK_RED), SetData(STR_ARG1, STR_NULL), SetPadding(2, 2, 2, 2),
+					Widget(WT_DROPDOWN_BUTTON, CIW_ENTRANCE_RECOLOUR3, COL_RANGE_DARK_RED), SetData(STR_ARG1, STR_NULL), SetPadding(2, 2, 2, 2),
+					SetResize(1, 0),
+				Intermediate(1, 3),
+					Widget(WT_DROPDOWN_BUTTON, CIW_EXIT_RECOLOUR1, COL_RANGE_DARK_RED), SetData(STR_ARG1, STR_NULL), SetPadding(2, 2, 2, 2),
+					Widget(WT_DROPDOWN_BUTTON, CIW_EXIT_RECOLOUR2, COL_RANGE_DARK_RED), SetData(STR_ARG1, STR_NULL), SetPadding(2, 2, 2, 2),
+					Widget(WT_DROPDOWN_BUTTON, CIW_EXIT_RECOLOUR3, COL_RANGE_DARK_RED), SetData(STR_ARG1, STR_NULL), SetPadding(2, 2, 2, 2),
+					SetResize(1, 0),
+
 		Widget(WT_TEXT_PUSHBUTTON, CIW_REMOVE, COL_RANGE_DARK_RED),
 				SetData(GUI_ENTITY_REMOVE, GUI_ENTITY_REMOVE_TOOLTIP),
 	EndContainer(),
@@ -110,12 +141,20 @@ public:
 
 	void SetWidgetStringParameters(WidgetNumber wid_num) const override;
 	void OnClick(WidgetNumber widget, const Point16 &pos) override;
+	void OnChange(ChangeCode code, uint32 parameter) override;
+	void SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos) override;
+	void SelectorMouseButtonEvent(uint8 state) override;
 
-	void SetCoasterStateForRadioButton(WidgetNumber radio);
+	void SetCoasterState();
 	void SetRadioChecked(WidgetNumber radio, bool checked);
+	void UpdateRecolourButtons();
 
 private:
 	CoasterInstance *ci; ///< Roller coaster instance to display and control.
+
+	void ChooseEntranceExitClicked(bool entrance);
+	RideMouseMode entrance_exit_placement;
+	bool is_placing_entrance;
 };
 
 /**
@@ -126,13 +165,40 @@ CoasterInstanceWindow::CoasterInstanceWindow(CoasterInstance *ci) : GuiWindow(WC
 {
 	this->ci = ci;
 	this->SetupWidgetTree(_coaster_instance_gui_parts, lengthof(_coaster_instance_gui_parts));
+	this->SetCoasterState();
+	this->UpdateRecolourButtons();
+
+	entrance_exit_placement.cur_cursor = CUR_TYPE_INVALID;
+	/* When opening the window of a newly built ride immediately prompt the user to place the entrance or exit. */
+	if (this->ci->NeedsEntrance()) {
+		ChooseEntranceExitClicked(true);
+	} else if (this->ci->NeedsExit()) {
+		ChooseEntranceExitClicked(false);
+	}
 }
 
 CoasterInstanceWindow::~CoasterInstanceWindow()
 {
+	SetSelector(nullptr);
 	if (!GetWindowByType(WC_COASTER_BUILD, this->wnumber) && !this->ci->IsAccessible()) {
 		_rides_manager.DeleteInstance(this->ci->GetIndex());
 	}
+}
+
+assert_compile(MAX_RECOLOUR >= 3); ///< Check that the 3 recolourings of a gentle/thrill ride fit in the Recolouring::entries array.
+
+/** Update all recolour buttons of the window. */
+void CoasterInstanceWindow::UpdateRecolourButtons()
+{
+	for (int i = 0; i < 3; i++) {
+		const RecolourEntry &re = this->ci->entrance_recolours.entries[i];
+		this->GetWidget<LeafWidget>(CIW_ENTRANCE_RECOLOUR1 + i)->SetShaded(!re.IsValid());
+	}
+	for (int i = 0; i < 3; i++) {
+		const RecolourEntry &re = this->ci->exit_recolours.entries[i];
+		this->GetWidget<LeafWidget>(CIW_EXIT_RECOLOUR1 + i)->SetShaded(!re.IsValid());
+	}
+	ResetSize();
 }
 
 void CoasterInstanceWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
@@ -140,6 +206,25 @@ void CoasterInstanceWindow::SetWidgetStringParameters(WidgetNumber wid_num) cons
 	switch (wid_num) {
 		case CIW_TITLEBAR:
 			_str_params.SetUint8(1, (uint8 *)this->ci->name.get());
+			break;
+
+		case CIW_ENTRANCE_RECOLOUR1:
+			_str_params.SetStrID(1, _rides_manager.entrances[this->ci->entrance_type]->recolour_description_1);
+			break;
+		case CIW_ENTRANCE_RECOLOUR2:
+			_str_params.SetStrID(1, _rides_manager.entrances[this->ci->entrance_type]->recolour_description_2);
+			break;
+		case CIW_ENTRANCE_RECOLOUR3:
+			_str_params.SetStrID(1, _rides_manager.entrances[this->ci->entrance_type]->recolour_description_3);
+			break;
+		case CIW_EXIT_RECOLOUR1:
+			_str_params.SetStrID(1, _rides_manager.exits[this->ci->exit_type]->recolour_description_1);
+			break;
+		case CIW_EXIT_RECOLOUR2:
+			_str_params.SetStrID(1, _rides_manager.exits[this->ci->exit_type]->recolour_description_2);
+			break;
+		case CIW_EXIT_RECOLOUR3:
+			_str_params.SetStrID(1, _rides_manager.exits[this->ci->exit_type]->recolour_description_3);
 			break;
 	}
 }
@@ -157,11 +242,83 @@ void CoasterInstanceWindow::OnClick(WidgetNumber widget, const Point16 &pos)
 			break;
 
 		case CIW_CLOSE:
-		case CIW_TEST:
-		case CIW_OPEN:
-			this->SetCoasterStateForRadioButton(widget);
+			this->ci->CloseRide();
+			this->SetCoasterState();
 			break;
+		case CIW_TEST:
+			this->ci->TestRide();
+			this->SetCoasterState();
+			break;
+		case CIW_OPEN:
+			if (this->ci->CanOpenRide()) this->ci->OpenRide();
+			this->SetCoasterState();
+			break;
+
+		case CIW_ENTRANCE_RECOLOUR1:
+		case CIW_ENTRANCE_RECOLOUR2:
+		case CIW_ENTRANCE_RECOLOUR3: {
+			RecolourEntry *re = &this->ci->entrance_recolours.entries[widget - CIW_ENTRANCE_RECOLOUR1];
+			if (re->IsValid()) {
+				this->ShowRecolourDropdown(widget, re, COL_RANGE_DARK_RED);
+			}
+			break;
+		}
+		case CIW_EXIT_RECOLOUR1:
+		case CIW_EXIT_RECOLOUR2:
+		case CIW_EXIT_RECOLOUR3: {
+			RecolourEntry *re = &this->ci->exit_recolours.entries[widget - CIW_EXIT_RECOLOUR1];
+			if (re->IsValid()) {
+				this->ShowRecolourDropdown(widget, re, COL_RANGE_DARK_RED);
+			}
+			break;
+		}
+
+		case CIW_PLACE_ENTRANCE:
+			ChooseEntranceExitClicked(true);
+			break;
+		case CIW_PLACE_EXIT:
+			ChooseEntranceExitClicked(false);
+			break;
+
+		case CIW_CHOOSE_ENTRANCE: {
+			DropdownList itemlist;
+			for (int i = 0; _rides_manager.entrances[i] != nullptr; i++) {
+				_str_params.SetUint8(1, _language.GetText(_rides_manager.entrances[i]->name));
+				itemlist.push_back(DropdownItem(STR_ARG1));
+			}
+			this->ShowDropdownMenu(widget, itemlist, this->ci->entrance_type, COL_RANGE_DARK_RED);
+			break;
+		}
+		case CIW_CHOOSE_EXIT: {
+			DropdownList itemlist;
+			for (int i = 0; _rides_manager.exits[i] != nullptr; i++) {
+				_str_params.SetUint8(1, _language.GetText(_rides_manager.exits[i]->name));
+				itemlist.push_back(DropdownItem(STR_ARG1));
+			}
+			this->ShowDropdownMenu(widget, itemlist, this->ci->exit_type, COL_RANGE_DARK_RED);
+			break;
+		}
 	}
+}
+
+/**
+ * Called when the Choose Entrance or Choose Exit button was clicked.
+ * @param entrance Entrance or exit button.
+ */
+void CoasterInstanceWindow::ChooseEntranceExitClicked(const bool entrance)
+{
+	this->ci->temp_entrance_pos = XYZPoint16::invalid();
+	this->ci->temp_exit_pos = XYZPoint16::invalid();
+
+	if (this->selector == nullptr || (this->is_placing_entrance != entrance)) {
+		this->is_placing_entrance = entrance;
+		SetSelector(&entrance_exit_placement);
+	} else {
+		SetSelector(nullptr);
+	}
+
+	entrance_exit_placement.SetSize(0, 0);
+	entrance_exit_placement.MarkDirty();
 }
 
 /**
@@ -171,33 +328,14 @@ void CoasterInstanceWindow::OnClick(WidgetNumber widget, const Point16 &pos)
  *
  * @param radio A radio button that was clicked by the user.
  */
-void CoasterInstanceWindow::SetCoasterStateForRadioButton(WidgetNumber radio)
+void CoasterInstanceWindow::SetCoasterState()
 {
-	switch (radio) {
-		case CIW_CLOSE:
-			this->ci->CloseRide();
-			break;
+	this->SetRadioChecked(CIW_CLOSE, this->ci->state == RIS_CLOSED);
+	this->SetRadioChecked(CIW_TEST, this->ci->state == RIS_TESTING);
+	this->SetRadioChecked(CIW_OPEN, this->ci->state == RIS_OPEN);
 
-		case CIW_TEST:
-			this->ci->TestRide();
-			break;
-
-		case CIW_OPEN:
-			/// \todo implement ride opening
-			break;
-
-		default:
-			NOT_REACHED();
-	}
-
-	this->SetRadioChecked(radio, true);
-
-	WidgetNumber radioButtons[] = { CIW_CLOSE, CIW_TEST, CIW_OPEN };
-	for(uint i = 0; i < lengthof(radioButtons); i++){
-		if(radioButtons[i] != radio){
-			this->SetRadioChecked(radioButtons[i], false);
-		}
-	}
+	this->GetWidget<LeafWidget>(CIW_OPEN)->SetShaded(!this->ci->CanOpenRide());
+	/* \todo Disable the Test button if the track is not closed. */
 }
 
 /**
@@ -212,6 +350,101 @@ void CoasterInstanceWindow::SetRadioChecked(WidgetNumber radio, bool checked)
 	this->MarkWidgetDirty(radio);
 }
 
+void CoasterInstanceWindow::OnChange(const ChangeCode code, const uint32 parameter)
+{
+	switch (code) {
+		case CHG_DISPLAY_OLD:
+			this->MarkDirty();
+			break;
+		case CHG_DROPDOWN_RESULT:
+			switch ((parameter >> 16) & 0xFF) {
+				case CIW_CHOOSE_ENTRANCE:
+					this->ci->SetEntranceType(parameter & 0xFF);
+					this->UpdateRecolourButtons();
+					break;
+				case CIW_CHOOSE_EXIT:
+					this->ci->SetExitType(parameter & 0xFF);
+					this->UpdateRecolourButtons();
+					break;
+				default:
+					break;
+			}
+			break;
+		default:
+			break;
+	}
+}
+
+void CoasterInstanceWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
+{
+	const Point32 world_pos = vp->ComputeHorizontalTranslation(vp->rect.width / 2 - pos.x, vp->rect.height / 2 - pos.y);
+	int dx, dy;
+	switch (vp->orientation) {
+		case VOR_NORTH: dx =  1; dy =  1; break;
+		case VOR_WEST:  dx = -1; dy =  1; break;
+		case VOR_SOUTH: dx = -1; dy = -1; break;
+		case VOR_EAST:  dx =  1; dy = -1; break;
+		default: NOT_REACHED();
+	}
+
+	entrance_exit_placement.MarkDirty();
+	bool placed = false;
+	for (int z = WORLD_Z_SIZE - 1; z >= 0; z--) {
+		const int dz = (z - (vp->view_pos.z / 256)) / 2;
+		const XYZPoint16 location(world_pos.x / 256 + dz * dx, world_pos.y / 256 + dz * dy, z);
+		if (!this->ci->CanPlaceEntranceOrExit(location, this->is_placing_entrance, nullptr)) continue;
+
+		if (this->is_placing_entrance) {
+			this->ci->temp_entrance_pos = location;
+		} else {
+			this->ci->temp_exit_pos = location;
+		}
+		this->entrance_exit_placement.SetSize(1, 1);
+		this->entrance_exit_placement.SetPosition(location.x, location.y);
+		this->entrance_exit_placement.AddVoxel(location);
+		this->entrance_exit_placement.SetupRideInfoSpace();
+		this->entrance_exit_placement.SetRideData(location, static_cast<SmallRideInstance>(this->ci->GetIndex()), SHF_ENTRANCE_BITS);
+		placed = true;
+		break;
+	}
+	if (!placed) {
+		if (this->is_placing_entrance) {
+			this->ci->temp_entrance_pos = XYZPoint16::invalid();
+		} else {
+			this->ci->temp_exit_pos = XYZPoint16::invalid();
+		}
+		entrance_exit_placement.SetSize(0, 0);
+	}
+	entrance_exit_placement.MarkDirty();
+}
+
+void CoasterInstanceWindow::SelectorMouseButtonEvent(const uint8 state)
+{
+	if (!IsLeftClick(state)) return;
+	if (entrance_exit_placement.area.width != 1 || entrance_exit_placement.area.height != 1) return;
+
+	if (this->ci->PlaceEntranceOrExit(this->is_placing_entrance ? this->ci->temp_entrance_pos : this->ci->temp_exit_pos, this->is_placing_entrance, nullptr)) {
+		this->ci->temp_entrance_pos = XYZPoint16::invalid();
+		this->ci->temp_exit_pos = XYZPoint16::invalid();
+		SetSelector(nullptr);
+
+		/* If the user is still in the process of building the ride, immediately prompt for the placement of another side-building as well. */
+		const bool need_entrance = this->ci->NeedsEntrance();
+		const bool need_exit = this->ci->NeedsExit();
+		if (this->is_placing_entrance && need_exit) {
+			/* After placing an entrance, preferably build an exit next. */
+			ChooseEntranceExitClicked(false);
+		} else if (!this->is_placing_entrance && need_entrance) {
+			/* After placing an exit, preferably build an entrance next. */
+			ChooseEntranceExitClicked(true);
+		} else if (need_entrance) {
+			ChooseEntranceExitClicked(true);
+		} else if (need_exit) {
+			ChooseEntranceExitClicked(false);
+		}
+	}
+}
+
 /**
  * Open a roller coaster management window for the given roller coaster ride.
  * @param coaster Coaster instance to display.
@@ -222,8 +455,22 @@ void ShowCoasterManagementGui(RideInstance *coaster)
 	CoasterInstance *ci = static_cast<CoasterInstance *>(coaster);
 	assert(ci != nullptr);
 
-	RideInstanceState ris = ci->DecideRideState();
-	if (ris == RIS_TESTING || ris == RIS_CLOSED || ris == RIS_OPEN) {
+	const int old_state = ci->state;
+	const int ris = ci->DecideRideState();
+	if (old_state != ris) {
+		switch (old_state) {
+			case RIS_OPEN:
+				ci->OpenRide();
+				break;
+			case RIS_TESTING:
+				ci->TestRide();
+				break;
+			default:
+				ci->CloseRide();
+				break;
+		}
+	}
+	if (ci->state == RIS_TESTING || ci->state == RIS_CLOSED || ci->state == RIS_OPEN) {
 		if (HighlightWindowByType(WC_COASTER_MANAGER, coaster->GetIndex())) return;
 
 		new CoasterInstanceWindow(ci);

--- a/src/fixed_ride_type.cpp
+++ b/src/fixed_ride_type.cpp
@@ -131,11 +131,12 @@ int FixedRideInstance::EntranceExitRotation(const XYZPoint16& vox) const
 	NOT_REACHED();  // Invalid entrance/exit location.
 }
 
-void FixedRideInstance::GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const
+void FixedRideInstance::GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const
 {
 	sprites[0] = nullptr;
 	sprites[2] = nullptr;
 	sprites[3] = nullptr;
+	if (platform != nullptr && vox.z == this->vox_pos.z) *platform = PATH_NE_NW_SE_SW;
 
 	auto orientation_index = [orient](const int o) {
 		return (4 + o - orient) & 3;

--- a/src/fixed_ride_type.cpp
+++ b/src/fixed_ride_type.cpp
@@ -60,26 +60,6 @@ FixedRideInstance::~FixedRideInstance()
 }
 
 /**
- * Whether the ride's entrance should be rendered at the given location.
- * @param pos Absolute voxel in the world.
- * @return An entrance is located at the given location.
- */
-bool FixedRideInstance::IsEntranceLocation(const XYZPoint16& pos) const
-{
-	return false;
-}
-
-/**
- * Whether the ride's exit should be rendered at the given location.
- * @param pos Absolute voxel in the world.
- * @return An exit is located at the given location.
- */
-bool FixedRideInstance::IsExitLocation(const XYZPoint16& pos) const
-{
-	return false;
-}
-
-/**
  * Determine at which voxel in the world a ride piece should be located.
  * @param orientation Orientation of the fixed ride.
  * @param x Unrotated x coordinate of the ride piece, relative to the ride's base voxel.

--- a/src/fixed_ride_type.h
+++ b/src/fixed_ride_type.h
@@ -64,7 +64,7 @@ public:
 	~FixedRideInstance();
 
 	const FixedRideType *GetFixedRideType() const;
-	void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const override;
+	void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const override;
 
 	virtual void SetRide(uint8 orientation, const XYZPoint16 &pos);
 	void RemoveAllPeople() override;

--- a/src/fixed_ride_type.h
+++ b/src/fixed_ride_type.h
@@ -78,8 +78,6 @@ public:
 	void InsertIntoWorld() override;
 	void RemoveFromWorld() override;
 
-	virtual bool IsEntranceLocation(const XYZPoint16& pos) const;
-	virtual bool IsExitLocation(const XYZPoint16& pos) const;
 	int EntranceExitRotation(const XYZPoint16& vox) const;
 
 	uint8 orientation;  ///< Orientation of the shop.

--- a/src/gentle_thrill_ride_gui.cpp
+++ b/src/gentle_thrill_ride_gui.cpp
@@ -192,20 +192,20 @@ GentleThrillRideManagerWindow::~GentleThrillRideManagerWindow()
 	SetSelector(nullptr);
 }
 
-assert_compile(MAX_RECOLOUR >= 3); ///< Check that the 3 recolourings of a gentle/thrill ride fit in the Recolouring::entries array.
+assert_compile(MAX_RECOLOUR >= MAX_RIDE_RECOLOURS); ///< Check that the 3 recolourings of a gentle/thrill ride fit in the Recolouring::entries array.
 
 /** Update all recolour buttons of the window. */
 void GentleThrillRideManagerWindow::UpdateRecolourButtons()
 {
-	for (int i = 0; i < 3; i++) {
+	for (int i = 0; i < MAX_RIDE_RECOLOURS; i++) {
 		const RecolourEntry &re = this->ride->recolours.entries[i];
 		this->GetWidget<LeafWidget>(GTRMW_RECOLOUR1 + i)->SetShaded(!re.IsValid());
 	}
-	for (int i = 0; i < 3; i++) {
+	for (int i = 0; i < MAX_RIDE_RECOLOURS; i++) {
 		const RecolourEntry &re = this->ride->entrance_recolours.entries[i];
 		this->GetWidget<LeafWidget>(GTRMW_ENTRANCE_RECOLOUR1 + i)->SetShaded(!re.IsValid());
 	}
-	for (int i = 0; i < 3; i++) {
+	for (int i = 0; i < MAX_RIDE_RECOLOURS; i++) {
 		const RecolourEntry &re = this->ride->exit_recolours.entries[i];
 		this->GetWidget<LeafWidget>(GTRMW_EXIT_RECOLOUR1 + i)->SetShaded(!re.IsValid());
 	}
@@ -362,14 +362,8 @@ void GentleThrillRideManagerWindow::ChooseEntranceExitClicked(const bool entranc
 void GentleThrillRideManagerWindow::SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos)
 {
 	const Point32 world_pos = vp->ComputeHorizontalTranslation(vp->rect.width / 2 - pos.x, vp->rect.height / 2 - pos.y);
-	int dx, dy;
-	switch (vp->orientation) {
-		case VOR_NORTH: dx =  1; dy =  1; break;
-		case VOR_WEST:  dx = -1; dy =  1; break;
-		case VOR_SOUTH: dx = -1; dy = -1; break;
-		case VOR_EAST:  dx =  1; dy = -1; break;
-		default: NOT_REACHED();
-	}
+	const int8 dx = _orientation_signum_dx[vp->orientation];
+	const int8 dy = _orientation_signum_dy[vp->orientation];
 	const int dz = (this->ride->vox_pos.z - (vp->view_pos.z / 256)) / 2;
 	const XYZPoint16 location(world_pos.x / 256 + dz * dx, world_pos.y / 256 + dz * dy, this->ride->vox_pos.z);
 

--- a/src/gentle_thrill_ride_gui.cpp
+++ b/src/gentle_thrill_ride_gui.cpp
@@ -194,7 +194,7 @@ GentleThrillRideManagerWindow::~GentleThrillRideManagerWindow()
 
 assert_compile(MAX_RECOLOUR >= 3); ///< Check that the 3 recolourings of a gentle/thrill ride fit in the Recolouring::entries array.
 
-/** Update all recolour buttons of the wondow. */
+/** Update all recolour buttons of the window. */
 void GentleThrillRideManagerWindow::UpdateRecolourButtons()
 {
 	for (int i = 0; i < 3; i++) {

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -178,6 +178,7 @@ uint8 *Loader::GetText()
  */
 void Loader::SetFailMessage(const char *fail_msg)
 {
+	fprintf(stderr, "ERROR while loading: %s\n", fail_msg);
 	if (this->IsFail()) return; // Do not overwrite the first message.
 	this->fail_msg = fail_msg;
 }

--- a/src/orientation.h
+++ b/src/orientation.h
@@ -10,6 +10,7 @@
 #ifndef ORIENTATION_H
 #define ORIENTATION_H
 
+#include "stdafx.h"
 #include "tile.h"
 
 /**
@@ -25,6 +26,9 @@ enum ViewOrientation {
 	VOR_NUM_ORIENT = 4,   ///< Number of orientations.
 	VOR_INVALID = 0xFF,   ///< Invalid orientation.
 };
+
+extern const int8 _orientation_signum_dx[VOR_NUM_ORIENT];
+extern const int8 _orientation_signum_dy[VOR_NUM_ORIENT];
 
 /**
  * Rotate view 90 degrees clockwise.

--- a/src/orientation_func.cpp
+++ b/src/orientation_func.cpp
@@ -1,0 +1,31 @@
+/*
+ * This file is part of FreeRCT.
+ * FreeRCT is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 2.
+ * FreeRCT is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with FreeRCT. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file orientation_func.cpp Orientation functions. */
+
+#include "orientation.h"
+
+/**
+ * The direction factor (\c 1 or \c -1) by which the x world coordinate changes depending on the
+ * viewport orientation when stepping down a visual line that is orthogonal to the viewport.
+ */
+const int8 _orientation_signum_dx[VOR_NUM_ORIENT] = {
+	+1, ///< VOR_NORTH
+	+1, ///< VOR_EAST
+	-1, ///< VOR_SOUTH
+	-1, ///< VOR_WEST
+};
+/**
+ * The direction factor (\c 1 or \c -1) by which the y world coordinate changes depending on the
+ * viewport orientation when stepping down a visual line that is orthogonal to the viewport.
+ */
+const int8 _orientation_signum_dy[VOR_NUM_ORIENT] = {
+	+1, ///< VOR_NORTH
+	-1, ///< VOR_EAST
+	-1, ///< VOR_SOUTH
+	+1, ///< VOR_WEST
+};

--- a/src/ride_build.cpp
+++ b/src/ride_build.cpp
@@ -287,14 +287,9 @@ RidePlacementResult RideBuildWindow::ComputeFixedRideVoxel(XYZPoint32 world_pos,
 	const FixedRideType *st = si->GetFixedRideType();
 	assert(st != nullptr);
 
-	int dx, dy; // Change of xworld and yworld for every (zworld / 2) change.
-	switch (vp_orient) {
-		case VOR_NORTH: dx =  1; dy =  1; break;
-		case VOR_WEST:  dx = -1; dy =  1; break;
-		case VOR_SOUTH: dx = -1; dy = -1; break;
-		case VOR_EAST:  dx =  1; dy = -1; break;
-		default: NOT_REACHED();
-	}
+	/* Change of xworld and yworld for every (zworld / 2) change. */
+	const int8 dx = _orientation_signum_dx[vp_orient];
+	const int8 dy = _orientation_signum_dy[vp_orient];
 
 	XYZPoint16 vox_pos;
 	/* Move to the top voxel of the world. */

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -229,12 +229,13 @@ const RideType *RideInstance::GetRideType() const
 }
 
 /**
- * \fn void RideInstance::GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const
+ * \fn void RideInstance::GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const
  * Get the sprites to display for the provided voxel number.
  * @param vox The voxel's absolute coordinates.
  * @param voxel_number Number of the voxel to draw (copied from the world voxel data).
  * @param orient View orientation.
  * @param sprites [out] Sprites to draw, from back to front, #SO_PLATFORM_BACK, #SO_RIDE, #SO_RIDE_FRONT, and #SO_PLATFORM_FRONT.
+ * @param platform [out] Shape of the support platform, if needed. @see PathSprites
  */
 
 /**

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -297,6 +297,26 @@ const Recolouring *RideInstance::GetRecolours(const XYZPoint16 &pos) const
 }
 
 /**
+ * Whether the ride's entrance should be rendered at the given location.
+ * @param pos Absolute voxel in the world.
+ * @return An entrance is located at the given location.
+ */
+bool RideInstance::IsEntranceLocation(const XYZPoint16& pos) const
+{
+	return false;
+}
+
+/**
+ * Whether the ride's exit should be rendered at the given location.
+ * @param pos Absolute voxel in the world.
+ * @return An exit is located at the given location.
+ */
+bool RideInstance::IsExitLocation(const XYZPoint16& pos) const
+{
+	return false;
+}
+
+/**
  * Sell an item to a customer.
  * @param item_index Index of the item being sold.
  */
@@ -461,7 +481,7 @@ void RideInstance::HandleBreakdown()
  */
 bool RideInstance::CanOpenRide() const
 {
-	return this->state == RIS_CLOSED;
+	return this->state == RIS_CLOSED || this->state == RIS_TESTING;
 }
 
 /**

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -159,7 +159,7 @@ public:
 	RideInstance(const RideType *rt);
 	virtual ~RideInstance() = default;
 
-	virtual void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4]) const = 0;
+	virtual void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const = 0;
 	virtual const Recolouring *GetRecolours(const XYZPoint16 &pos) const;
 	virtual uint8 GetEntranceDirections(const XYZPoint16 &vox) const = 0;
 	virtual RideEntryResult EnterRide(int guest, TileEdge entry_edge) = 0;

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -189,6 +189,8 @@ public:
 	void HandleBreakdown();
 	void SetEntranceType(int type);
 	void SetExitType(int type);
+	virtual bool IsEntranceLocation(const XYZPoint16& pos) const;
+	virtual bool IsExitLocation(const XYZPoint16& pos) const;
 
 	virtual void Load(Loader &ldr);
 	virtual void Save(Saver &svr);

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -20,6 +20,8 @@ static const int MAX_RIDE_INSTANCE_NAME_LENGTH = 64; ///< Maximum number of char
 static const uint16 INVALID_RIDE_INSTANCE      = 0xFFFF; ///< Value representing 'no ride instance found'.
 static const int MAX_NUMBER_OF_RIDE_ENTRANCES_EXITS = 32; ///< Maximal number of types of ride entrances or exits.
 
+static const int MAX_RIDE_RECOLOURS = 3;  ///< Maximum number of entries in a RideInstance's recolour map.
+
 static const int NUMBER_ITEM_TYPES_SOLD = 2; ///< Number of different items that a ride can sell.
 
 static const int BREAKDOWN_GRACE_PERIOD = 30; ///< Number of days to wait before random breakdowns after first time opening ride.

--- a/src/shop_gui.cpp
+++ b/src/shop_gui.cpp
@@ -173,13 +173,13 @@ ShopManagerWindow::ShopManagerWindow(ShopInstance *ri) : GuiWindow(WC_SHOP_MANAG
 	this->SetupWidgetTree(_shop_manager_gui_parts, lengthof(_shop_manager_gui_parts));
 	this->SetShopToggleButtons();
 
-	for (int i = 0; i < 3; i++) {
+	for (int i = 0; i < MAX_RIDE_RECOLOURS; i++) {
 		const RecolourEntry &re = this->shop->recolours.entries[i];
 		if (!re.IsValid()) this->GetWidget<LeafWidget>(SMW_RECOLOUR1 + i)->SetShaded(true);
 	}
 }
 
-assert_compile(MAX_RECOLOUR >= 3); ///< Check that the 3 recolourings of a shop fit in the Recolouring::entries array.
+assert_compile(MAX_RECOLOUR >= MAX_RIDE_RECOLOURS); ///< Check that the 3 recolourings of a shop fit in the Recolouring::entries array.
 
 /** Update the radio buttons of the window. */
 void ShopManagerWindow::SetShopToggleButtons()

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -453,14 +453,10 @@ static int DrawRide(int32 slice, const XYZPoint16 & pos, const Point32 base_pos,
 {
 	const RideInstance *ri = _rides_manager.GetRideInstance(number);
 	if (ri == nullptr) return 0;
-	/* Fixed rides are connected in every direction. */
-	if (platform != nullptr) *platform = (
-			(ri->GetKind() == RTK_SHOP || ri->GetKind() == RTK_GENTLE || ri->GetKind() == RTK_THRILL) &&
-			pos.z == static_cast<const FixedRideInstance*>(ri)->vox_pos.z) ?
-		PATH_NE_NW_SE_SW : PATH_INVALID;
 
+	if (platform != nullptr) *platform = PATH_INVALID;
 	const ImageData *sprites[4];
-	ri->GetSprites(pos, voxel_number, orient, sprites);
+	ri->GetSprites(pos, voxel_number, orient, sprites, platform);
 
 	int idx = 0;
 	static const SpriteOrder sprite_numbers[4] = {SO_PLATFORM_BACK, SO_RIDE, SO_RIDE_FRONT, SO_PLATFORM_FRONT};


### PR DESCRIPTION
Coasters have entrances and exits now. As they can have multiple stations, every station needs to have exactly one entrance and and one exit, otherwise the ride can't be opened.
The ride's opened/testing/closed state is now fully under the control of the radiobuttons rather than automatically putting the coaster in test mode upon opening its window.
Guests cannot actually visit coasters yet.