### PR TITLE
Guests on Coasters

### DIFF
--- a/graphics/rcd/lang/de_DE.txt
+++ b/graphics/rcd/lang/de_DE.txt
@@ -191,6 +191,10 @@ strings {
 		COASTER_BUILD_BANK_RIGHT_TOOLTIP: "Wählt Streckenteile mit Neigung nach rechts aus";
 		COASTER_BUILD_BUY_TOOLTIP:        "Kauft das gewählte Streckenteil";
 
+		// Coaster management strings.
+		COASTER_MANAGER_NUMBER_TRAINS:  "Züge: %1%";
+		COASTER_MANAGER_NUMBER_CARS:    "Wagen: %1%";
+
 		// Entity remove button strings.
 		ENTITY_REMOVE:         "Abreißen";
 		ENTITY_REMOVE_TOOLTIP: "Das hier abreißen?";

--- a/graphics/rcd/lang/en_GB.txt
+++ b/graphics/rcd/lang/en_GB.txt
@@ -191,6 +191,10 @@ strings {
 		COASTER_BUILD_BANK_RIGHT_TOOLTIP: "Selects track pieces that end with a banking to the right";
 		COASTER_BUILD_BUY_TOOLTIP:        "Click to buy the selected track piece";
 
+		// Coaster management strings.
+		COASTER_MANAGER_NUMBER_TRAINS:  "Trains: %1%";
+		COASTER_MANAGER_NUMBER_CARS:    "Cars: %1%";
+
 		// Entity remove button strings.
 		ENTITY_REMOVE:         "Remove";
 		ENTITY_REMOVE_TOOLTIP: "Remove this?";

--- a/graphics/rcd/lang/nds_DE.txt
+++ b/graphics/rcd/lang/nds_DE.txt
@@ -191,6 +191,10 @@ strings {
 		COASTER_BUILD_BANK_RIGHT_TOOLTIP: "Spoordelen mit Schüünte na rechts utkören";
 		COASTER_BUILD_BUY_TOOLTIP:        "Klick, um dat utköört Spoordeel to kopen";
 
+		// Coaster management strings.
+		COASTER_MANAGER_NUMBER_TRAINS:  "Zügen: %1%";
+		COASTER_MANAGER_NUMBER_CARS:    "Wagens: %1%";
+
 		// Entity remove button strings.
 		ENTITY_REMOVE:         "Ofrieten";
 		ENTITY_REMOVE_TOOLTIP: "Dat hier ofrieten?";

--- a/graphics/rcd/tracks.txt
+++ b/graphics/rcd/tracks.txt
@@ -14,8 +14,8 @@ file("tracks.rcd") {
 	RCST {
 		coaster_type: 1; // Simple coaster tracks.
 		platform_type: 1; // Wooden platforms.
-		max_number_trains: 2;
-		max_number_cars: 1;
+		max_number_trains: 3;
+		max_number_cars: 4;
 
 		texts: strings { key: "basic-coaster"; }
 

--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -24,6 +24,9 @@ CoasterPlatform _coaster_platforms[CPT_COUNT]; ///< Sprites for the coaster plat
 static CarType _car_types[16]; ///< Car types available to the program (arbitrary limit).
 static uint _used_types = 0;   ///< First free car type in #_car_types.
 
+static const int32 TRAIN_DEPARTURE_INTERVAL = 30000;        ///< How many milliseconds a train should wait in the station. \todo Make this user-configurable.
+static const int32 TRAIN_DEPARTURE_INTERVAL_TESTING = 3000; ///< How many milliseconds a train should wait in the station in test mode.
+
 static const uint16 ENTRANCE_OR_EXIT = INT16_MAX;  ///< Indicates that a voxel belongs to an entrance or exit.
 
 /**
@@ -104,7 +107,7 @@ bool CoasterType::Load(RcdFileReader *rcd_file, const TextMap &texts, const Trac
 	if (this->platform_type == 0 || this->platform_type >= CPT_COUNT) return false;
 
 	this->item_type[0] = ITP_RIDE;
-	this->item_cost[0] = 100;  // Entrance fee. NOCOM read from RCD.
+	this->item_cost[0] = 100;  // Entrance fee. \todo Read this from the RCD file.
 	this->item_cost[1] = 0;    // Unused.
 
 	TextData *text_data;
@@ -329,9 +332,6 @@ void CoasterCar::PreRemove()
 	this->front.PreRemove();
 	this->back.PreRemove();
 }
-
-static const int32 TRAIN_DEPARTURE_INTERVAL = 30000; ///< How many milliseconds a train should wait in the station. NOCOM Make this user-configurable.
-static const int32 TRAIN_DEPARTURE_INTERVAL_TESTING = 3000; ///< How many milliseconds a train should wait in the station in test mode.
 
 CoasterTrain::CoasterTrain()
 {
@@ -877,7 +877,7 @@ RideEntryResult CoasterInstance::EnterRide(int guest_id, const XYZPoint16 &vox, 
 		auto it = free_slots.begin();
 		std::advance(it, r.Uniform(free_slots.size() - 1));
 		it->first->guests[it->second] = guest;
-		if (free_slots.size() == 1) loading_train->time_left_waiting = 0;  // NOCOM consider minimum waiting time
+		if (free_slots.size() == 1) loading_train->time_left_waiting = 0;  // \todo Allow defining a minimum waiting time.
 		return RER_ENTERED;
 	}
 	NOT_REACHED();

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -13,7 +13,7 @@
 #include <map>
 #include <vector>
 #include "map.h"
-#include "ride_type.h"
+#include "person.h"
 #include "track_piece.h"
 
 static const int MAX_PLACED_TRACK_PIECES = 1024; ///< Maximum number of track pieces in a single roller coaster.
@@ -135,27 +135,14 @@ public:
 /** Coaster car drawn at the front and the back position. */
 class CoasterCar {
 public:
-	DisplayCoasterCar front; ///< %Voxel image displayed at the front of the car.
-	DisplayCoasterCar back;  ///< %Voxel image displayed at the end of the car.
+	DisplayCoasterCar front;     ///< %Voxel image displayed at the front of the car.
+	DisplayCoasterCar back;      ///< %Voxel image displayed at the end of the car.
+	std::vector<Guest*> guests;  ///< Guests currently in the car.
 
-	/** Car is about to be removed from the train, clean up if necessary. */
-	void PreRemove()
-	{
-		this->front.PreRemove();
-		this->back.PreRemove();
-	}
+	void PreRemove();
 
-	void Load(Loader &ldr)
-	{
-		this->front.Load(ldr);
-		this->back.Load(ldr);
-	}
-
-	void Save(Saver &svr)
-	{
-		this->front.Save(svr);
-		this->back.Save(svr);
-	}
+	void Load(Loader &ldr);
+	void Save(Saver &svr);
 };
 
 /** How a coaster train is behaving in regard to a station. */
@@ -200,6 +187,7 @@ struct CoasterStation {
 	std::vector<XYZPoint16> locations;  ///< Voxels occupied by the station.
 	TileEdge direction;                 ///< The start direction of the station's first tile.
 	uint32 length;                      ///< The station's length in pixels.
+	uint32 back_position;               ///< Position of the begin of the station in 1/256 pixels.
 	XYZPoint16 entrance;                ///< Position of the station's entrance (may be \c invalid()).
 	XYZPoint16 exit;                    ///< Position of the station's exit (may be \c invalid()).
 };
@@ -233,13 +221,14 @@ public:
 
 	void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const override;
 	uint8 GetEntranceDirections(const XYZPoint16 &vox) const override;
-	RideEntryResult EnterRide(int guest, TileEdge entry) override;
+	RideEntryResult EnterRide(int guest, const XYZPoint16 &vox, TileEdge entry) override;
 	XYZPoint32 GetExit(int guest, TileEdge entry_edge) override;
 	void RemoveAllPeople() override;
 	bool CanOpenRide() const override;
 	bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const override;
 	bool PathEdgeWanted(const XYZPoint16 &vox, TileEdge edge) const override;
 	const Recolouring *GetRecolours(const XYZPoint16 &pos) const override;
+	void InitializeItemPricesAndStatistics() override;
 
 	bool MakePositionedPiecesLooping(bool *modified);
 	int GetFirstPlacedTrackPiece() const;

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -176,8 +176,8 @@ public:
 	uint32 back_position;                  ///< Position of the back-end of the train (in 1/256 pixels).
 	int32 speed;                           ///< Amount of forward motion / millisecond, in 1/256 pixels.
 	const PositionedTrackPiece *cur_piece; ///< Track piece that has the back-end position of the train.
-	TrainStationPolicy station_policy;     ///< The train is supposed to stop when reaching the front of the station.
-	int32 time_left_waiting;               ///< The number of milliseconds this train should still wait in a station before departing.
+	TrainStationPolicy station_policy;     ///< The train's behaviour regarding stations.
+	int32 time_left_waiting;               ///< The number of milliseconds left this train should wait in a station before departing.
 };
 
 /** A station belonging to a coaster. */
@@ -277,7 +277,7 @@ public:
 	uint32 coaster_length;        ///< Total length of the roller coaster track (in 1/256 pixels).
 	int number_of_trains;         ///< Current number of trains.
 	int cars_per_train;           ///< Current number of cars in each train.
-	CoasterTrain trains[12];      ///< Trains at the roller coaster (with an arbitrary max size). A train without cars means the train is not used.
+	CoasterTrain trains[4];       ///< Trains at the roller coaster (with an arbitrary max size). A train without cars means the train is not used.
 	const CarType *car_type;      ///< Type of cars running at the coaster.
 	std::vector<CoasterStation> stations;  ///< All stations of this coaster.
 	XYZPoint16 temp_entrance_pos;          ///< Temporary location of one of the ride's entrance while the user is moving the entrance.

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -158,6 +158,14 @@ public:
 	}
 };
 
+/** How a coaster train is behaving in regard to a station. */
+enum TrainStationPolicy {
+	TSP_LEAVING_STATION,   ///< The train is leaving a station.
+	TSP_ENTERING_STATION,  ///< The train is entering a station.
+	TSP_IN_STATION,        ///< The train is waiting motionlessly in a station.
+	TSP_NO_STATION,        ///< The train is nowhere near a station.
+};
+
 class CoasterInstance;
 
 /**
@@ -181,7 +189,8 @@ public:
 	uint32 back_position;                  ///< Position of the back-end of the train (in 1/256 pixels).
 	int32 speed;                           ///< Amount of forward motion / millisecond, in 1/256 pixels.
 	const PositionedTrackPiece *cur_piece; ///< Track piece that has the back-end position of the train.
-	bool halt;                             ///< The train is frozen in place until this is \c false.
+	TrainStationPolicy station_policy;     ///< The train is supposed to stop when reaching the front of the station.
+	int32 time_left_waiting;               ///< The number of milliseconds this train should still wait in a station before departing.
 };
 
 /** A station belonging to a coaster. */
@@ -261,7 +270,7 @@ public:
 	int GetMaxNumberOfCars() const;
 	void SetNumberOfTrains(int number_trains);
 	void SetNumberOfCars(int number_cars);
-	void ReinitializeTrains(bool halt);
+	void ReinitializeTrains(bool test_mode);
 
 	void Load(Loader &ldr);
 	void Save(Saver &svr);

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -184,7 +184,7 @@ public:
 	void Load(Loader &ldr);
 	void Save(Saver &svr);
 
-	const CoasterInstance *coaster;        ///< Roller coaster owning the train.
+	CoasterInstance *coaster;              ///< Roller coaster owning the train.
 	std::vector<CoasterCar> cars;          ///< Cars in the train. \c 0 means the train is not used.
 	uint32 back_position;                  ///< Position of the back-end of the train (in 1/256 pixels).
 	int32 speed;                           ///< Amount of forward motion / millisecond, in 1/256 pixels.
@@ -271,6 +271,7 @@ public:
 	void SetNumberOfTrains(int number_trains);
 	void SetNumberOfCars(int number_cars);
 	void ReinitializeTrains(bool test_mode);
+	void Crash(CoasterTrain *t1, CoasterTrain *t2);
 
 	void Load(Loader &ldr);
 	void Save(Saver &svr);

--- a/src/coaster.h
+++ b/src/coaster.h
@@ -181,6 +181,7 @@ public:
 	uint32 back_position;                  ///< Position of the back-end of the train (in 1/256 pixels).
 	int32 speed;                           ///< Amount of forward motion / millisecond, in 1/256 pixels.
 	const PositionedTrackPiece *cur_piece; ///< Track piece that has the back-end position of the train.
+	bool halt;                             ///< The train is frozen in place until this is \c false.
 };
 
 /** A station belonging to a coaster. */
@@ -189,6 +190,7 @@ struct CoasterStation {
 
 	std::vector<XYZPoint16> locations;  ///< Voxels occupied by the station.
 	TileEdge direction;                 ///< The start direction of the station's first tile.
+	uint32 length;                      ///< The station's length in pixels.
 	XYZPoint16 entrance;                ///< Position of the station's entrance (may be \c invalid()).
 	XYZPoint16 exit;                    ///< Position of the station's exit (may be \c invalid()).
 };
@@ -218,6 +220,7 @@ public:
 	}
 
 	void TestRide();
+	void OpenRide() override;
 
 	void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const override;
 	uint8 GetEntranceDirections(const XYZPoint16 &vox) const override;
@@ -228,8 +231,6 @@ public:
 	bool CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const override;
 	bool PathEdgeWanted(const XYZPoint16 &vox, TileEdge edge) const override;
 	const Recolouring *GetRecolours(const XYZPoint16 &pos) const override;
-
-	RideInstanceState DecideRideState();
 
 	bool MakePositionedPiecesLooping(bool *modified);
 	int GetFirstPlacedTrackPiece() const;
@@ -253,13 +254,14 @@ public:
 	void PlaceTrackPieceInWorld(const PositionedTrackPiece &piece);
 	void RemoveTrackPieceInWorld(const PositionedTrackPiece &piece);
 
-	int GetMaxNumberOfTrains() const;
-	void SetNumberOfTrains(int number_trains);
-	int GetNumberOfTrains() const;
-
+	uint32 GetShortestStation() const;
+	uint32 GetTrainLength(int cars_per_train) const;
+	uint32 GetTrainSpacing() const;
+	int GetMaxNumberOfTrains(int cars_per_train) const;
 	int GetMaxNumberOfCars() const;
+	void SetNumberOfTrains(int number_trains);
 	void SetNumberOfCars(int number_cars);
-	int GetNumberOfCars() const;
+	void ReinitializeTrains(bool halt);
 
 	void Load(Loader &ldr);
 	void Save(Saver &svr);
@@ -274,7 +276,9 @@ public:
 	PositionedTrackPiece *pieces; ///< Positioned track pieces.
 	int capacity;                 ///< Number of entries in the #pieces.
 	uint32 coaster_length;        ///< Total length of the roller coaster track (in 1/256 pixels).
-	CoasterTrain trains[4];       ///< Trains at the roller coaster (with an arbitrary max size). A train without cars means the train is not used.
+	int number_of_trains;         ///< Current number of trains.
+	int cars_per_train;           ///< Current number of cars in each train.
+	CoasterTrain trains[12];      ///< Trains at the roller coaster (with an arbitrary max size). A train without cars means the train is not used.
 	const CarType *car_type;      ///< Type of cars running at the coaster.
 	std::vector<CoasterStation> stations;  ///< All stations of this coaster.
 	XYZPoint16 temp_entrance_pos;          ///< Temporary location of one of the ride's entrance while the user is moving the entrance.

--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -404,11 +404,13 @@ void CoasterInstanceWindow::OnChange(const ChangeCode code, const uint32 paramet
 					this->ci->SetExitType(parameter & 0xFF);
 					this->UpdateRecolourButtons();
 					break;
-				case CIW_NUMBER_CARS:
-					this->ci->SetNumberOfCars((parameter & 0xFF) + 1 /* Counting from 1 on because there can not be 0 cars/trains. */);
-					break;
 				case CIW_NUMBER_TRAINS:
-					this->ci->SetNumberOfTrains((parameter & 0xFF) + 1);
+					this->ci->SetNumberOfTrains((parameter & 0xFF) + 1 /* Counting from 1 on because there can not be 0 cars/trains. */);
+					break;
+				case CIW_NUMBER_CARS:
+					this->ci->SetNumberOfCars((parameter & 0xFF) + 1);
+					/* This also updates the positions of all trains in case the train length changed. */
+					this->ci->SetNumberOfTrains(std::min(this->ci->number_of_trains, this->ci->GetMaxNumberOfTrains(this->ci->number_of_trains)));
 					break;
 				default:
 					break;

--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -84,7 +84,7 @@ enum CoasterInstanceWidgets {
 	CIW_EXIT_RECOLOUR2,      ///< Second exit colour.
 	CIW_EXIT_RECOLOUR3,      ///< Third exit colour.
 	CIW_NUMBER_TRAINS,       ///< Number of trains dropdown.
-	CIW_NUMBER_CARS,       ///< Number of cars dropdown.
+	CIW_NUMBER_CARS,         ///< Number of cars dropdown.
 };
 
 /** Widget parts of the #CoasterInstanceWindow. */
@@ -253,7 +253,7 @@ void CoasterInstanceWindow::OnClick(WidgetNumber widget, const Point16 &pos)
 		case CIW_EDIT:
 			this->ci->CloseRide();
 			ShowCoasterBuildGui(this->ci);
-			delete this;  // Allowing the user to change ride settings while the coaster is under construction can cause all sorts of nasty crashes.
+			delete this;  // The user must not change ride settings while the coaster is under construction.
 			break;
 
 		case CIW_CLOSE:
@@ -369,10 +369,7 @@ void CoasterInstanceWindow::SetCoasterState()
 	this->SetRadioChecked(CIW_CLOSE, this->ci->state == RIS_CLOSED);
 	this->SetRadioChecked(CIW_TEST, this->ci->state == RIS_TESTING);
 	this->SetRadioChecked(CIW_OPEN, this->ci->state == RIS_OPEN);
-
 	this->GetWidget<LeafWidget>(CIW_OPEN)->SetShaded(!this->ci->CanOpenRide());
-	/* \todo Disable the Test button if the track is not closed. */
-
 	this->GetWidget<LeafWidget>(CIW_NUMBER_CARS)->SetShaded(this->ci->state != RIS_CLOSED);
 	this->GetWidget<LeafWidget>(CIW_NUMBER_TRAINS)->SetShaded(this->ci->state != RIS_CLOSED);
 }

--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -253,6 +253,7 @@ void CoasterInstanceWindow::OnClick(WidgetNumber widget, const Point16 &pos)
 		case CIW_EDIT:
 			this->ci->CloseRide();
 			ShowCoasterBuildGui(this->ci);
+			delete this;  // Allowing the user to change ride settings while the coaster is under construction can cause all sorts of nasty crashes.
 			break;
 
 		case CIW_CLOSE:

--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -482,6 +482,7 @@ void CoasterInstanceWindow::SelectorMouseButtonEvent(const uint8 state)
 		} else if (need_exit) {
 			ChooseEntranceExitClicked(false);
 		}
+		SetCoasterState();
 	}
 }
 
@@ -506,7 +507,11 @@ void ShowCoasterManagementGui(RideInstance *coaster)
 	if (ci->cars_per_train < 1) ci->SetNumberOfCars(ci->GetMaxNumberOfCars());
 	if (ci->number_of_trains < 1) ci->SetNumberOfTrains(ci->GetMaxNumberOfTrains(ci->cars_per_train));
 
-	if (HighlightWindowByType(WC_COASTER_MANAGER, coaster->GetIndex())) return;
+	Window *w;
+	if (HighlightWindowByType(WC_COASTER_MANAGER, coaster->GetIndex(), &w)) {
+		static_cast<CoasterInstanceWindow*>(w)->SetCoasterState();
+		return;
+	}
 	new CoasterInstanceWindow(ci);
 }
 

--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -60,7 +60,7 @@ void CoasterRemoveWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
  */
 void ShowCoasterRemove(CoasterInstance *ci)
 {
-	if (HighlightWindowByType(WC_COASTER_REMOVE, ci->GetIndex())) return;
+	if (HighlightWindowByType(WC_COASTER_REMOVE, ci->GetIndex()) != nullptr) return;
 
 	new CoasterRemoveWindow(ci);
 }
@@ -504,8 +504,8 @@ void ShowCoasterManagementGui(RideInstance *coaster)
 	if (ci->cars_per_train < 1) ci->SetNumberOfCars(ci->GetMaxNumberOfCars());
 	if (ci->number_of_trains < 1) ci->SetNumberOfTrains(ci->GetMaxNumberOfTrains(ci->cars_per_train));
 
-	Window *w;
-	if (HighlightWindowByType(WC_COASTER_MANAGER, coaster->GetIndex(), &w)) {
+	Window *w = HighlightWindowByType(WC_COASTER_MANAGER, coaster->GetIndex());
+	if (w != nullptr) {
 		static_cast<CoasterInstanceWindow*>(w)->SetCoasterState();
 		return;
 	}
@@ -1132,7 +1132,7 @@ void CoasterBuildWindow::UpdateSelectedPiece()
 void ShowCoasterBuildGui(CoasterInstance *coaster)
 {
 	if (coaster->GetKind() != RTK_COASTER) return;
-	if (HighlightWindowByType(WC_COASTER_BUILD, coaster->GetIndex())) return;
+	if (HighlightWindowByType(WC_COASTER_BUILD, coaster->GetIndex()) != nullptr) return;
 
 	new CoasterBuildWindow(coaster);
 }

--- a/src/error_gui.cpp
+++ b/src/error_gui.cpp
@@ -69,6 +69,6 @@ void ErrorMessageWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
  */
 void ShowErrorMessage(StringID strid)
 {
-	if (HighlightWindowByType(WC_ERROR_MESSAGE, strid)) return;
+	if (HighlightWindowByType(WC_ERROR_MESSAGE, strid) != nullptr) return;
 	new ErrorMessageWindow(strid);
 }

--- a/src/fence_gui.cpp
+++ b/src/fence_gui.cpp
@@ -260,6 +260,6 @@ void FenceGui::SelectorMouseButtonEvent(uint8 state)
  */
 void ShowFenceGui()
 {
-	if (HighlightWindowByType(WC_FENCE, ALL_WINDOWS_OF_TYPE)) return;
+	if (HighlightWindowByType(WC_FENCE, ALL_WINDOWS_OF_TYPE) != nullptr) return;
 	new FenceGui;
 }

--- a/src/finances_gui.cpp
+++ b/src/finances_gui.cpp
@@ -120,6 +120,6 @@ void FinancesGui::SetWidgetStringParameters(WidgetNumber wid_num) const
 /** Open the finances window (or if it is already opened, highlight and raise it). */
 void ShowFinancesGui()
 {
-	if (HighlightWindowByType(WC_FINANCES, ALL_WINDOWS_OF_TYPE)) return;
+	if (HighlightWindowByType(WC_FINANCES, ALL_WINDOWS_OF_TYPE) != nullptr) return;
 	new FinancesGui;
 }

--- a/src/gentle_thrill_ride_gui.cpp
+++ b/src/gentle_thrill_ride_gui.cpp
@@ -60,7 +60,7 @@ void GentleThrillRideRemoveWindow::SetWidgetStringParameters(WidgetNumber wid_nu
  */
 void ShowGentleThrillRideRemove(GentleThrillRideInstance *si)
 {
-	if (HighlightWindowByType(WC_GENTLE_THRILL_RIDE_REMOVE, si->GetIndex())) return;
+	if (HighlightWindowByType(WC_GENTLE_THRILL_RIDE_REMOVE, si->GetIndex()) != nullptr) return;
 
 	new GentleThrillRideRemoveWindow(si);
 }
@@ -446,7 +446,7 @@ void GentleThrillRideManagerWindow::OnChange(const ChangeCode code, const uint32
  */
 void ShowGentleThrillRideManagementGui(uint16 number)
 {
-	if (HighlightWindowByType(WC_GENTLE_THRILL_RIDE_MANAGER, number)) return;
+	if (HighlightWindowByType(WC_GENTLE_THRILL_RIDE_MANAGER, number) != nullptr) return;
 
 	RideInstance *ri = _rides_manager.GetRideInstance(number);
 	if (ri == nullptr || (ri->GetKind() != RTK_GENTLE && ri->GetKind() != RTK_THRILL)) return;

--- a/src/gentle_thrill_ride_type.cpp
+++ b/src/gentle_thrill_ride_type.cpp
@@ -170,8 +170,9 @@ uint8 GentleThrillRideInstance::GetEntranceDirections(const XYZPoint16 &vox) con
 	return (vox == this->entrance_pos || vox == this->exit_pos) ? 1 << EntranceExitRotation(vox) : SHF_ENTRANCE_NONE;
 }
 
-RideEntryResult GentleThrillRideInstance::EnterRide(int guest, TileEdge entry)
+RideEntryResult GentleThrillRideInstance::EnterRide(int guest, const XYZPoint16 &vox, TileEdge entry)
 {
+	assert(vox == this->entrance_pos);
 	if (_guests.Get(guest)->cash < GetSaleItemPrice(0)) return RER_REFUSED;
 	const int b = onride_guests.GetLoadingBatch();
 	return (b >= 0 && this->onride_guests.batches[b].AddGuest(guest, entry)) ? RER_ENTERED : RER_WAIT;

--- a/src/gentle_thrill_ride_type.h
+++ b/src/gentle_thrill_ride_type.h
@@ -44,7 +44,7 @@ public:
 	bool CanOpenRide() const override;
 
 	uint8 GetEntranceDirections(const XYZPoint16 &vox) const override;
-	RideEntryResult EnterRide(int guest, TileEdge entry) override;
+	RideEntryResult EnterRide(int guest, const XYZPoint16 &vox, TileEdge entry) override;
 	XYZPoint32 GetExit(int guest, TileEdge entry_edge) override;
 	void InitializeItemPricesAndStatistics() override;
 

--- a/src/path_gui.cpp
+++ b/src/path_gui.cpp
@@ -852,6 +852,6 @@ void PathBuildGui::OnChange(ChangeCode code, uint32 parameter)
  */
 void ShowPathBuildGui()
 {
-	if (HighlightWindowByType(WC_PATH_BUILDER, ALL_WINDOWS_OF_TYPE)) return;
+	if (HighlightWindowByType(WC_PATH_BUILDER, ALL_WINDOWS_OF_TYPE) != nullptr) return;
 	new PathBuildGui;
 }

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -1310,7 +1310,7 @@ AnimateResult Guest::VisitRideOnAnimate(RideInstance *ri, TileEdge exit_edge)
 		/* All lights are green, let's try to enter the ride. */
 		this->activity = GA_ON_RIDE;
 		this->ride = ri;
-		const RideEntryResult rer = ri->EnterRide(this->id, exit_edge);
+		const RideEntryResult rer = ri->EnterRide(this->id, this->vox_pos, exit_edge);
 		if (rer == RER_WAIT) {
 			this->activity = GA_QUEUING;
 			return OAR_HALT;

--- a/src/person_gui.cpp
+++ b/src/person_gui.cpp
@@ -131,7 +131,7 @@ void GuestInfoWindow::OnChange(ChangeCode code, uint32 parameter)
  */
 void ShowGuestInfoGui(const Person *person)
 {
-	if (HighlightWindowByType(WC_GUEST_INFO, person->id)) return;
+	if (HighlightWindowByType(WC_GUEST_INFO, person->id) != nullptr) return;
 
 	const Guest *guest = dynamic_cast<const Guest *>(person);
 

--- a/src/rcdgen/string_names.h
+++ b/src/rcdgen/string_names.h
@@ -199,6 +199,10 @@ static const char *_gui_string_names[] = {
 	"COASTER_BUILD_BANK_RIGHT_TOOLTIP",
 	"COASTER_BUILD_BUY_TOOLTIP",
 
+	/* Coaster management window. */
+	"COASTER_MANAGER_NUMBER_TRAINS",
+	"COASTER_MANAGER_NUMBER_CARS",
+
 	/* Entity remove button. */
 	"ENTITY_REMOVE",
 	"ENTITY_REMOVE_TOOLTIP",

--- a/src/ride_build.cpp
+++ b/src/ride_build.cpp
@@ -414,7 +414,7 @@ void RideBuildWindow::SelectorMouseButtonEvent(uint8 state)
  */
 void ShowRideBuildGui(RideInstance *ri)
 {
-	if (HighlightWindowByType(WC_RIDE_BUILD, ri->GetIndex())) return;
+	if (HighlightWindowByType(WC_RIDE_BUILD, ri->GetIndex()) != nullptr) return;
 
 	new RideBuildWindow(ri);
 }

--- a/src/ride_gui.cpp
+++ b/src/ride_gui.cpp
@@ -300,6 +300,6 @@ void RideSelectGui::SetNewRide(int number)
  */
 void ShowRideSelectGui()
 {
-	if (HighlightWindowByType(WC_RIDE_SELECT, ALL_WINDOWS_OF_TYPE)) return;
+	if (HighlightWindowByType(WC_RIDE_SELECT, ALL_WINDOWS_OF_TYPE) != nullptr) return;
 	new RideSelectGui;
 }

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -246,12 +246,13 @@ const RideType *RideInstance::GetRideType() const
  */
 
 /**
- * \fn RideEntryResult RideInstance::EnterRide(int guest, TileEdge entry_edge)
+ * \fn RideEntryResult RideInstance::EnterRide(int guest, const XYZPoint16 &vox, TileEdge entry_edge)
  * The given guest tries to enter the ride. Meaning and further handling of the ride visit depends on the return value.
  * - If the call returns #RER_REFUSED, the guest is not given entry (ride is full), it should be tried again at another time.
  * - If the call returns #RER_ENTERED, the guest is given access, and is now staying in the ride. The ride calls Guest::ExitRide when it is done.
  * - If the call returns #RER_DONE, the guest is given access, and the ride is also immediately visited (Guest::ExitRide is called before returning this answer).
  * @param guest Number of the guest entering the ride.
+ * @param vox Position of the voxel with the ride.
  * @param entry_edge Edge of entering the ride. Value is passed back through Guest::ExitRide, to use as parameter in RideInstance::GetExit.
  * @return Whether the guest is accepted, and if so, if the guest is staying inside.
  */
@@ -523,6 +524,7 @@ void RideInstance::OpenRide()
 void RideInstance::CloseRide()
 {
 	this->state = RIS_CLOSED;
+	this->RemoveAllPeople();
 }
 
 /**

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -164,7 +164,7 @@ public:
 	virtual void GetSprites(const XYZPoint16 &vox, uint16 voxel_number, uint8 orient, const ImageData *sprites[4], uint8 *platform) const = 0;
 	virtual const Recolouring *GetRecolours(const XYZPoint16 &pos) const;
 	virtual uint8 GetEntranceDirections(const XYZPoint16 &vox) const = 0;
-	virtual RideEntryResult EnterRide(int guest, TileEdge entry_edge) = 0;
+	virtual RideEntryResult EnterRide(int guest, const XYZPoint16 &vox, TileEdge entry_edge) = 0;
 	virtual XYZPoint32 GetExit(int guest, TileEdge entry_edge) = 0;
 	virtual void RemoveAllPeople() = 0;
 	virtual void RemoveFromWorld() = 0;

--- a/src/setting_gui.cpp
+++ b/src/setting_gui.cpp
@@ -143,6 +143,6 @@ void SettingWindow::OnChange(ChangeCode code, uint32 parameter)
  */
 void ShowSettingGui()
 {
-	if (HighlightWindowByType(WC_SETTING, ALL_WINDOWS_OF_TYPE)) return;
+	if (HighlightWindowByType(WC_SETTING, ALL_WINDOWS_OF_TYPE) != nullptr) return;
 	new SettingWindow();
 }

--- a/src/shop_gui.cpp
+++ b/src/shop_gui.cpp
@@ -57,7 +57,7 @@ void ShopRemoveWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
  */
 void ShowShopRemove(ShopInstance *si)
 {
-	if (HighlightWindowByType(WC_SHOP_REMOVE, si->GetIndex())) return;
+	if (HighlightWindowByType(WC_SHOP_REMOVE, si->GetIndex()) != nullptr) return;
 
 	new ShopRemoveWindow(si);
 }
@@ -290,7 +290,7 @@ void ShopManagerWindow::OnChange(ChangeCode code, uint32 parameter)
  */
 void ShowShopManagementGui(uint16 number)
 {
-	if (HighlightWindowByType(WC_SHOP_MANAGER, number)) return;
+	if (HighlightWindowByType(WC_SHOP_MANAGER, number) != nullptr) return;
 
 	RideInstance *ri = _rides_manager.GetRideInstance(number);
 	if (ri == nullptr || ri->GetKind() != RTK_SHOP) return;

--- a/src/shop_type.cpp
+++ b/src/shop_type.cpp
@@ -171,8 +171,9 @@ bool ShopInstance::CanBeVisited(const XYZPoint16 &vox, TileEdge edge) const
 	return GB(this->GetEntranceDirections(vox), (edge + 2) % 4, 1) != 0;
 }
 
-RideEntryResult ShopInstance::EnterRide(int guest, TileEdge entry)
+RideEntryResult ShopInstance::EnterRide(int guest, const XYZPoint16 &vox, TileEdge entry)
 {
+	assert(vox == this->vox_pos);
 	if (this->onride_guests.num_batches == 0) { // No onride guests, handle it all now.
 		Guest *g = _guests.Get(guest);
 		g->ExitRide(this, entry);

--- a/src/shop_type.h
+++ b/src/shop_type.h
@@ -41,7 +41,7 @@ public:
 
 	void SetRide(uint8 orientation, const XYZPoint16 &pos) override;
 	uint8 GetEntranceDirections(const XYZPoint16 &vox) const override;
-	RideEntryResult EnterRide(int guest, TileEdge entry) override;
+	RideEntryResult EnterRide(int guest, const XYZPoint16 &vox, TileEdge entry) override;
 	XYZPoint32 GetExit(int guest, TileEdge entry_edge) override;
 
 	void Load(Loader &ldr) override;

--- a/src/terraform_gui.cpp
+++ b/src/terraform_gui.cpp
@@ -259,6 +259,6 @@ void TerraformGui::DecreaseSize()
 /** Open the terraform window (or if it is already opened, highlight and raise it). */
 void ShowTerraformGui()
 {
-	if (HighlightWindowByType(WC_TERRAFORM, ALL_WINDOWS_OF_TYPE)) return;
+	if (HighlightWindowByType(WC_TERRAFORM, ALL_WINDOWS_OF_TYPE) != nullptr) return;
 	new TerraformGui;
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1143,15 +1143,17 @@ void NotifyChange(WindowTypes wtype, WindowNumber wnumber, ChangeCode code, uint
  * Highlight and raise a window of a given type.
  * @param wtype %Window type to look for.
  * @param wnumber %Window number to look for (use #ALL_WINDOWS_OF_TYPE for any window of type \a wtype).
+ * @param window [out] If the return value is \c true, this will point to the highlighted window.
  * @return A window has been highlighted and raised.
  * @ingroup window_group
  */
-bool HighlightWindowByType(WindowTypes wtype, WindowNumber wnumber)
+bool HighlightWindowByType(WindowTypes wtype, WindowNumber wnumber, Window **window)
 {
 	Window *w = GetWindowByType(wtype, wnumber);
 	if (w != nullptr) {
 		_window_manager.RaiseWindow(w);
 		w->SetHighlight(true);
+		if (window != nullptr) *window = w;
 	}
 
 	return w != nullptr;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1143,18 +1143,15 @@ void NotifyChange(WindowTypes wtype, WindowNumber wnumber, ChangeCode code, uint
  * Highlight and raise a window of a given type.
  * @param wtype %Window type to look for.
  * @param wnumber %Window number to look for (use #ALL_WINDOWS_OF_TYPE for any window of type \a wtype).
- * @param window [out] If the return value is \c true, this will point to the highlighted window.
- * @return A window has been highlighted and raised.
+ * @return The window which has been highlighted and raised, or \c nullptr if no such window exists.
  * @ingroup window_group
  */
-bool HighlightWindowByType(WindowTypes wtype, WindowNumber wnumber, Window **window)
+Window *HighlightWindowByType(WindowTypes wtype, WindowNumber wnumber)
 {
 	Window *w = GetWindowByType(wtype, wnumber);
 	if (w != nullptr) {
 		_window_manager.RaiseWindow(w);
 		w->SetHighlight(true);
-		if (window != nullptr) *window = w;
 	}
-
-	return w != nullptr;
+	return w;
 }

--- a/src/window.h
+++ b/src/window.h
@@ -461,7 +461,7 @@ inline void GuiWindow::SetSelector(MouseModeSelector *selector)
 bool IsLeftClick(uint8 state);
 
 Window *GetWindowByType(WindowTypes wtype, WindowNumber wnumber);
-bool HighlightWindowByType(WindowTypes wtype, WindowNumber wnumber);
+bool HighlightWindowByType(WindowTypes wtype, WindowNumber wnumber, Window **window = nullptr);
 void NotifyChange(WindowTypes wtype, WindowNumber wnumber, ChangeCode code, uint32 parameter);
 
 class RideInstance;

--- a/src/window.h
+++ b/src/window.h
@@ -461,7 +461,7 @@ inline void GuiWindow::SetSelector(MouseModeSelector *selector)
 bool IsLeftClick(uint8 state);
 
 Window *GetWindowByType(WindowTypes wtype, WindowNumber wnumber);
-bool HighlightWindowByType(WindowTypes wtype, WindowNumber wnumber, Window **window = nullptr);
+Window *HighlightWindowByType(WindowTypes wtype, WindowNumber wnumber);
 void NotifyChange(WindowTypes wtype, WindowNumber wnumber, ChangeCode code, uint32 parameter);
 
 class RideInstance;


### PR DESCRIPTION
Coasters can now have multiple trains with multiple cars, configurable from the management window. Trains will wait in the station until the maximum number of guests has entered the train or a timeout (not configurable yet) elapsed. Guests can and do enter and exit coasters now. And if you forgot to test that the trains can actually climb over those hills before opening your ride, your guests will not like the consequences…