### PR TITLE
Fix some person/path positioning crashes

### DIFF
--- a/doc/savegame.rst
+++ b/doc/savegame.rst
@@ -159,6 +159,7 @@ Offset  Length  Version  Description
    ?       2      1-     Current walk information (animation), in compressed format.
    ?       2      1-     Current displayed frame of the animation.
    ?       2      1-     Remaining displayed time of the current frame.
+   ?       2      3-     The person's current status.
    ?       4      1-     "nsrp".
 ======  ======  =======  ======================================================
 
@@ -167,6 +168,7 @@ Version history
 
 - 1 (20210402) Initial version.
 - 2 (20210426) Moved ride index of guests and mechanics to Person.
+- 3 (20210509) Moved status of staff members to Person.
 
 
 Guest
@@ -224,7 +226,7 @@ Offset  Length  Version  Description
    0       4      1-     "stfm".
    4       4      1-     Version number.
    ?       ?      1-     Person_ data.
-   ?       2      1-     The person's current status.
+           2      1-1    The person's current status.
    ?       4      1-     "mfts".
 ======  ======  =======  ======================================================
 
@@ -232,6 +234,7 @@ Version history
 ...............
 
 - 1 (20210426) Initial version.
+- 2 (20210509) Moved status of staff members to Person.
 
 
 Mechanic

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -362,6 +362,8 @@ uint8 SetPathEdge(uint8 slope, TileEdge edge, bool connect)
  */
 static int GetQuePathEdgeConnectCount(uint8 impl_slope)
 {
+	if (impl_slope >= PATH_FLAT_COUNT) return 0;  // Since ramps can have at most 2 connections it is always safe to connect them.
+
 	uint8 exp_edges = _path_expand[impl_slope] & PATHMASK_EDGES;
 	if (exp_edges == 0) return 0;
 	if (exp_edges == PATHMASK_NE || exp_edges == PATHMASK_SE || exp_edges == PATHMASK_SW || exp_edges == PATHMASK_NW) return 1;

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -107,6 +107,7 @@ Person::Person() : VoxelObject(), rnd()
 	this->type = PERSON_INVALID;
 	this->name = nullptr;
 	this->ride = nullptr;
+	this->status = GUI_PERSON_STATUS_WANDER;
 
 	this->offset = this->rnd.Uniform(100);
 }
@@ -149,37 +150,244 @@ const uint8 *Person::GetName() const
 	return buffer;
 }
 
-/**
- * Compute the height of the path in the given voxel, at the given x/y position.
- * @param vox Coordinates of the voxel.
- * @param x_pos X position in the voxel.
- * @param y_pos Y position in the voxel.
- * @return Z height of the path in the voxel at the give position.
- * @todo Make it work at sloped surface too, in case the person ends up at path-less land.
- */
-static int16 GetZHeight(const XYZPoint16 &vox, int16 x_pos, int16 y_pos)
+/** Recompute the height of the person. */
+void Person::UpdateZPosition()
 {
-	const Voxel *v = _world.GetVoxel(vox);
+	Voxel *v = _world.GetCreateVoxel(this->vox_pos, false);
 	assert(v != nullptr);
 
 	if (HasValidPath(v)) {
 		uint8 slope = GetImplodedPathSlope(v);
-		if (slope < PATH_FLAT_COUNT) return 0;
+		if (slope < PATH_FLAT_COUNT) {
+			this->pix_pos.z = 0;
+			return;
+		}
 		switch (slope) {
-			case PATH_RAMP_NE: return x_pos;
-			case PATH_RAMP_NW: return y_pos;
-			case PATH_RAMP_SE: return 255 - y_pos;
-			case PATH_RAMP_SW: return 255 - x_pos;
+			case PATH_RAMP_NE: this->pix_pos.z =       this->pix_pos.x; return;
+			case PATH_RAMP_NW: this->pix_pos.z =       this->pix_pos.y; return;
+			case PATH_RAMP_SE: this->pix_pos.z = 255 - this->pix_pos.y; return;
+			case PATH_RAMP_SW: this->pix_pos.z = 255 - this->pix_pos.x; return;
 			default: NOT_REACHED();
 		}
 	}
+	/* No path here. */
 
-	if (v->GetGroundType() != GTP_INVALID && v->GetGroundSlope() == SL_FLAT) {
-		/* No path, but the land is flat. */
-		return 0;
+	if (v->GetGroundType() == GTP_INVALID) {
+		/* The person ended up above or below the ground. Fall down or teleport upwards. */
+		const VoxelStack *vs = _world.GetStack(this->vox_pos.x, this->vox_pos.y);
+		const int base_z = vs->base + vs->GetTopGroundOffset();
+		assert(base_z != this->vox_pos.z);
+
+		this->RemoveSelf(v);
+		this->vox_pos.z = base_z;
+		this->pix_pos.z = 0;
+		v = _world.GetCreateVoxel(this->vox_pos, false);
+		assert(v != nullptr);
+		assert(v->GetGroundType() != GTP_INVALID);
+		this->AddSelf(v);
+		if (HasValidPath(v)) return this->UpdateZPosition();  // Ended up on a path.
+		/* Fall through to slope detection. */
 	}
 
-	NOT_REACHED(); /// \todo No path here!
+	/* Pathless land. Discover on which part of the slope the person is standing. */
+
+	switch (v->GetGroundSlope()) {
+		/* Flat land. */
+		case ISL_FLAT: this->pix_pos.z = 0; return;
+
+		/* Ramps. */
+		case ISL_SOUTH_WEST: this->pix_pos.z =       this->pix_pos.x; return;
+		case ISL_EAST_SOUTH: this->pix_pos.z =       this->pix_pos.y; return;
+		case ISL_NORTH_WEST: this->pix_pos.z = 255 - this->pix_pos.y; return;
+		case ISL_NORTH_EAST: this->pix_pos.z = 255 - this->pix_pos.x; return;
+
+		/* One corner up. The voxel is split into a flat and a raised triangle. */
+		case ISL_NORTH:
+			if (this->pix_pos.x + this->pix_pos.y >= 255) {  // Flat triangle.
+				this->pix_pos.z = 0;
+			} else {  // Raised triangle.
+				this->pix_pos.z = 255 - (this->pix_pos.x + this->pix_pos.y);
+			}
+			return;
+		case ISL_SOUTH:
+			if (this->pix_pos.x + this->pix_pos.y <= 255) {  // Flat triangle.
+				this->pix_pos.z = 0;
+			} else {  // Raised triangle.
+				this->pix_pos.z = (this->pix_pos.x + this->pix_pos.y) - 255;
+			}
+			return;
+		case ISL_WEST:
+			if (this->pix_pos.x <= this->pix_pos.y) {  // Flat triangle.
+				this->pix_pos.z = 0;
+			} else {  // Raised triangle.
+				this->pix_pos.z = std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y);
+			}
+			return;
+		case ISL_EAST:
+			if (this->pix_pos.x >= this->pix_pos.y) {  // Flat triangle.
+				this->pix_pos.z = 0;
+			} else {  // Raised triangle.
+				this->pix_pos.z = std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y);
+			}
+			return;
+
+		/* Two opposite corners up. The voxel consists of two triangles raised in opposite directions. */
+		case ISL_NORTH_SOUTH:
+			if (this->pix_pos.x + this->pix_pos.y <= 255) {  // Like the raised triangle of a TSB_NORTH slope.
+				this->pix_pos.z = 255 - (this->pix_pos.x + this->pix_pos.y);
+			} else {  // Like the raised triangle of a TSB_SOUTH slope.
+				this->pix_pos.z = (this->pix_pos.x + this->pix_pos.y) - 255;
+			}
+			return;
+		case ISL_EAST_WEST:  // Like the raised triangles of a TSB_WEST or TSB_EAST slope.
+			this->pix_pos.z = std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y);
+			return;
+
+		/* One corner down. The voxel is split into a flat and a lowered triangle, similar to the 'one corner up' case. */
+		case ISL_NORTH_EAST_WEST:  // South corner down.
+			if (this->pix_pos.x + this->pix_pos.y <= 255) {  // Flat triangle.
+				this->pix_pos.z = 255;
+			} else {  // Lowered triangle.
+				this->pix_pos.z = 255 - ((this->pix_pos.x + this->pix_pos.y) - 255);
+			}
+			return;
+		case ISL_EAST_SOUTH_WEST:  // North corner down.
+			if (this->pix_pos.x + this->pix_pos.y >= 255) {  // Flat triangle.
+				this->pix_pos.z = 255;
+			} else {  // Lowered triangle.
+				this->pix_pos.z = this->pix_pos.x + this->pix_pos.y;
+			}
+			return;
+		case ISL_NORTH_EAST_SOUTH:  // West corner down.
+			if (this->pix_pos.x <= this->pix_pos.y) {  // Flat triangle.
+				this->pix_pos.z = 255;
+			} else {  // Lowered triangle.
+				this->pix_pos.z = 255 - (std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y));
+			}
+			return;
+		case ISL_NORTH_SOUTH_WEST:  // East corner down.
+			if (this->pix_pos.x >= this->pix_pos.y) {  // Flat triangle.
+				this->pix_pos.z = 255;
+			} else {  // Lowered triangle.
+				this->pix_pos.z = 255 - (std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y));
+			}
+			return;
+
+		/* Imploded slopes below. We additionally need to check if the person is in the correct half of the slope. */
+		case ISL_BOTTOM_STEEP_NORTH:
+			if (this->pix_pos.x + this->pix_pos.y <= 255) {  // Wrong part, move up.
+				this->RemoveSelf(v);
+				this->vox_pos.z++;
+				v = _world.GetCreateVoxel(this->vox_pos, false);
+				assert(v != nullptr);
+				assert(v->GetGroundType() != GTP_INVALID);
+				assert(v->GetGroundSlope() == ISL_TOP_STEEP_NORTH);
+				this->AddSelf(v);
+				this->UpdateZPosition();
+			} else {  // Like for voxels with a lowered south corner.
+				this->pix_pos.z = 255 - ((this->pix_pos.x + this->pix_pos.y) - 255);
+			}
+			return;
+		case ISL_BOTTOM_STEEP_SOUTH:
+			if (this->pix_pos.x + this->pix_pos.y >= 255) {  // Wrong part, move up.
+				this->RemoveSelf(v);
+				this->vox_pos.z++;
+				v = _world.GetCreateVoxel(this->vox_pos, false);
+				assert(v != nullptr);
+				assert(v->GetGroundType() != GTP_INVALID);
+				assert(v->GetGroundSlope() == ISL_TOP_STEEP_SOUTH);
+				this->AddSelf(v);
+				this->UpdateZPosition();
+			} else {  // Like for voxels with a lowered north corner.
+				this->pix_pos.z = this->pix_pos.x + this->pix_pos.y;
+			}
+			return;
+		case ISL_BOTTOM_STEEP_EAST:
+			if (this->pix_pos.x <= this->pix_pos.y) {  // Wrong part, move up.
+				this->RemoveSelf(v);
+				this->vox_pos.z++;
+				v = _world.GetCreateVoxel(this->vox_pos, false);
+				assert(v != nullptr);
+				assert(v->GetGroundType() != GTP_INVALID);
+				assert(v->GetGroundSlope() == ISL_TOP_STEEP_EAST);
+				this->AddSelf(v);
+				this->UpdateZPosition();
+			} else {  // Like for voxels with a lowered west corner.
+				this->pix_pos.z = 255 - (std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y));
+			}
+		case ISL_BOTTOM_STEEP_WEST:
+			if (this->pix_pos.x >= this->pix_pos.y) {  // Wrong part, move up.
+				this->RemoveSelf(v);
+				this->vox_pos.z++;
+				v = _world.GetCreateVoxel(this->vox_pos, false);
+				assert(v != nullptr);
+				assert(v->GetGroundType() != GTP_INVALID);
+				assert(v->GetGroundSlope() == ISL_TOP_STEEP_WEST);
+				this->AddSelf(v);
+				this->UpdateZPosition();
+			} else {  // Like for voxels with a lowered east corner.
+				this->pix_pos.z = 255 - (std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y));
+			}
+			return;
+		case ISL_TOP_STEEP_NORTH:
+			if (this->pix_pos.x + this->pix_pos.y > 255) {  // Wrong part, move down.
+				this->RemoveSelf(v);
+				this->vox_pos.z--;
+				v = _world.GetCreateVoxel(this->vox_pos, false);
+				assert(v != nullptr);
+				assert(v->GetGroundType() != GTP_INVALID);
+				assert(v->GetGroundSlope() == ISL_BOTTOM_STEEP_NORTH);
+				this->AddSelf(v);
+				this->UpdateZPosition();
+			} else {  // Like for voxels with a raised north corner.
+				this->pix_pos.z = 255 - (this->pix_pos.x + this->pix_pos.y);
+			}
+			return;
+		case ISL_TOP_STEEP_SOUTH:
+			if (this->pix_pos.x + this->pix_pos.y < 255) {  // Wrong part, move down.
+				this->RemoveSelf(v);
+				this->vox_pos.z--;
+				v = _world.GetCreateVoxel(this->vox_pos, false);
+				assert(v != nullptr);
+				assert(v->GetGroundType() != GTP_INVALID);
+				assert(v->GetGroundSlope() == ISL_BOTTOM_STEEP_SOUTH);
+				this->AddSelf(v);
+				this->UpdateZPosition();
+			} else {  // Like for voxels with a raised south corner.
+				this->pix_pos.z = (this->pix_pos.x + this->pix_pos.y) - 255;
+			}
+			return;
+		case ISL_TOP_STEEP_EAST:
+			if (this->pix_pos.x < this->pix_pos.y) {  // Wrong part, move down.
+				this->RemoveSelf(v);
+				this->vox_pos.z--;
+				v = _world.GetCreateVoxel(this->vox_pos, false);
+				assert(v != nullptr);
+				assert(v->GetGroundType() != GTP_INVALID);
+				assert(v->GetGroundSlope() == ISL_BOTTOM_STEEP_EAST);
+				this->AddSelf(v);
+				this->UpdateZPosition();
+			} else {  // Like for voxels with a raised east corner.
+				this->pix_pos.z = std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y);
+			}
+			return;
+		case ISL_TOP_STEEP_WEST:
+			if (this->pix_pos.x < this->pix_pos.y) {  // Wrong part, move down.
+				this->RemoveSelf(v);
+				this->vox_pos.z--;
+				v = _world.GetCreateVoxel(this->vox_pos, false);
+				assert(v != nullptr);
+				assert(v->GetGroundType() != GTP_INVALID);
+				assert(v->GetGroundSlope() == ISL_BOTTOM_STEEP_WEST);
+				this->AddSelf(v);
+				this->UpdateZPosition();
+			} else {  // Like for voxels with a raised west corner.
+				this->pix_pos.z = std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y);
+			}
+			return;
+
+		default: NOT_REACHED();
+	}
 }
 
 /**
@@ -194,6 +402,7 @@ void Person::Activate(const Point16 &start, PersonType person_type)
 
 	this->type = person_type;
 	this->name.reset();
+	this->SetStatus(GUI_PERSON_STATUS_WANDER);
 
 	/* Set up the person sprite recolouring table. */
 	const PersonTypeData &person_type_data = GetPersonTypeData(this->type);
@@ -218,7 +427,7 @@ void Person::Activate(const Point16 &start, PersonType person_type)
 		this->pix_pos.x = 128 - this->offset;
 		this->pix_pos.y = 255;
 	}
-	this->pix_pos.z = GetZHeight(this->vox_pos, this->pix_pos.x, this->pix_pos.y);
+	this->UpdateZPosition();
 
 	this->DecideMoveDirection();
 }
@@ -609,9 +818,9 @@ private:
 	uint16 value;  ///< Encoded value to store in savegames.
 };
 
-static const uint32 CURRENT_VERSION_Person      = 2;   ///< Currently supported version of %Person.
+static const uint32 CURRENT_VERSION_Person      = 3;   ///< Currently supported version of %Person.
 static const uint32 CURRENT_VERSION_Guest       = 3;   ///< Currently supported version of %Guest.
-static const uint32 CURRENT_VERSION_StaffMember = 1;   ///< Currently supported version of %StaffMember.
+static const uint32 CURRENT_VERSION_StaffMember = 2;   ///< Currently supported version of %StaffMember.
 static const uint32 CURRENT_VERSION_Mechanic    = 2;   ///< Currently supported version of %Mechanic.
 static const uint32 CURRENT_VERSION_Handyman    = 1;   ///< Currently supported version of %Handyman.
 static const uint32 CURRENT_VERSION_Guard       = 1;   ///< Currently supported version of %Guard.
@@ -644,6 +853,8 @@ void Person::Load(Loader &ldr)
 	this->frame_index = ldr.GetWord();
 	this->frame_time = (int16)ldr.GetWord();
 
+	if (version >= 3) this->status = GUI_PERSON_STATUS_WANDER + ldr.GetWord();
+
 	const Animation *anim = _sprite_manager.GetAnimation(walk->anim_type, this->type);
 	assert(anim != nullptr && anim->frame_count != 0);
 
@@ -674,6 +885,7 @@ void Person::Save(Saver &svr)
 	svr.PutWord(WalkEncoder::Encode(this->walk));
 	svr.PutWord(this->frame_index);
 	svr.PutWord((uint16)this->frame_time);
+	svr.PutWord(this->status - GUI_PERSON_STATUS_WANDER);
 	svr.EndPattern();
 }
 
@@ -808,6 +1020,7 @@ void Guest::ExitRide(RideInstance *ri, TileEdge entry)
 	this->vox_pos.z = exit_pos.z >> 8; this->pix_pos.z = exit_pos.z & 0xff;
 	this->activity = GA_WANDER;
 	this->AddSelf(_world.GetCreateVoxel(this->vox_pos, false));
+	this->UpdateZPosition();
 	this->DecideMoveDirection();
 }
 
@@ -1092,6 +1305,7 @@ void Guest::DecideMoveDirection()
 	}
 
 	this->StartAnimation(new_walk);
+	this->SetStatus(this->ride != nullptr ? GUI_PERSON_STATUS_HEADING_TO_RIDE : GUI_PERSON_STATUS_WANDER);
 }
 
 /**
@@ -1321,7 +1535,7 @@ AnimateResult Person::OnAnimate(int delay)
 		this->frame_index %= this->frame_count;
 		this->frame_time = this->frames[this->frame_index].duration;
 
-		this->pix_pos.z = GetZHeight(this->vox_pos, this->pix_pos.x, this->pix_pos.y);
+		this->UpdateZPosition();
 		return OAR_OK;
 	}
 
@@ -1444,7 +1658,8 @@ AnimateResult Person::OnAnimate(int delay)
 		this->DecideMoveDirection();
 		return OAR_OK;
 	}
-	return OAR_DEACTIVATE; // We are truly lost now.
+
+	NOT_REACHED(); // We are truly lost now.
 }
 
 /**
@@ -2061,7 +2276,7 @@ void Guest::BuyItem(RideInstance *ri)
 /* Constructor. */
 StaffMember::StaffMember()
 {
-	this->status = GUI_PERSON_STATUS_WANDER;
+	/* Nothing to do currently. */
 }
 
 /* Destructor. */
@@ -2075,7 +2290,7 @@ void StaffMember::Load(Loader &ldr)
 	const uint32 version = ldr.OpenPattern("stfm");
 	if (version < 1 || version > CURRENT_VERSION_StaffMember) ldr.version_mismatch(version, CURRENT_VERSION_StaffMember);
 	this->Person::Load(ldr);
-	this->status = GUI_PERSON_STATUS_WANDER + ldr.GetWord();
+	if (version < 2) this->status = GUI_PERSON_STATUS_WANDER + ldr.GetWord();
 	ldr.ClosePattern();
 }
 
@@ -2083,15 +2298,14 @@ void StaffMember::Save(Saver &svr)
 {
 	svr.StartPattern("stfm", CURRENT_VERSION_StaffMember);
 	this->Person::Save(svr);
-	svr.PutWord(this->status - GUI_PERSON_STATUS_WANDER);
 	svr.EndPattern();
 }
 
 /**
- * Create this staff member's current status string.
+ * Create this person's current status string.
  * @return The status string.
  */
-const uint8 *StaffMember::GetStatus() const
+const uint8 *Person::GetStatus() const
 {
 	static char text_buffer[1024];
 	const char *text = reinterpret_cast<const char*>(_language.GetText(this->status));
@@ -2104,10 +2318,10 @@ const uint8 *StaffMember::GetStatus() const
 }
 
 /**
- * Change this staff member's current status.
+ * Change this person's current status.
  * @param s New status.
  */
-void StaffMember::SetStatus(StringID s)
+void Person::SetStatus(StringID s)
 {
 	this->status = s;
 	NotifyChange(WC_PERSON_INFO, this->id, CHG_DISPLAY_OLD, 0);

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -315,6 +315,7 @@ void Person::UpdateZPosition()
 			} else {  // Like for voxels with a lowered west corner.
 				this->pix_pos.z = 255 - (std::max(this->pix_pos.x, this->pix_pos.y) - std::min(this->pix_pos.x, this->pix_pos.y));
 			}
+			return;
 		case ISL_BOTTOM_STEEP_WEST:
 			if (this->pix_pos.x >= this->pix_pos.y) {  // Wrong part, move up.
 				this->RemoveSelf(v);
@@ -358,7 +359,7 @@ void Person::UpdateZPosition()
 			}
 			return;
 		case ISL_TOP_STEEP_EAST:
-			if (this->pix_pos.x < this->pix_pos.y) {  // Wrong part, move down.
+			if (this->pix_pos.x > this->pix_pos.y) {  // Wrong part, move down.
 				this->RemoveSelf(v);
 				this->vox_pos.z--;
 				v = _world.GetCreateVoxel(this->vox_pos, false);

--- a/src/person.h
+++ b/src/person.h
@@ -134,6 +134,7 @@ public:
 
 	void SetName(const uint8 *name);
 	const uint8 *GetName() const;
+	const uint8 *GetStatus() const;
 
 	uint16 id;       ///< Unique id of the person.
 	PersonType type; ///< Type of person.
@@ -150,6 +151,7 @@ public:
 protected:
 	Random rnd; ///< Random number generator for deciding how the person reacts.
 	std::unique_ptr<uint8[]> name; ///< Name of the person. \c nullptr means it has a default name (like "Guest XYZ").
+	StringID status;  ///< What the person is doing right now, for display in the GUI.
 
 	TileEdge GetCurrentEdge() const;
 	uint8 GetInparkDirections();
@@ -164,6 +166,8 @@ protected:
 	virtual AnimateResult VisitRideOnAnimate(RideInstance *ri, TileEdge exit_edge) = 0;
 	virtual AnimateResult InteractWithPathObject(PathObjectInstance *obj);
 	virtual bool IsLeavingPath() const;
+	void UpdateZPosition();
+	void SetStatus(StringID s);
 };
 
 /** Activities of the guest. */
@@ -266,15 +270,7 @@ public:
 	AnimateResult VisitRideOnAnimate(RideInstance *ri, TileEdge exit_edge) override;
 	RideVisitDesire WantToVisit(const RideInstance *ri, const XYZPoint16 &ride_pos, TileEdge exit_edge) override;
 
-	const uint8 *GetStatus() const;
-
 	static const std::map<PersonType, Money> SALARY;   ///< The monthly salary for each staff member.
-
-protected:
-	void SetStatus(StringID s);
-
-private:
-	StringID status;  ///< What we're doing right now.
 };
 
 /** A mechanic who can repair and inspect rides. */

--- a/src/person_gui.cpp
+++ b/src/person_gui.cpp
@@ -19,6 +19,7 @@
 /** Widgets of the guest info window. */
 enum GuestInfoWidgets {
 	GIW_TITLEBAR,     ///< Title bar widget.
+	GIW_STATUS,       ///< Status text.
 	GIW_MONEY,        ///< Current amount of money.
 	GIW_MONEY_SPENT,  ///< Total amount of money spent.
 	GIW_HAPPINESS,    ///< Happiness level.
@@ -37,6 +38,8 @@ static const WidgetPart _guest_info_gui_parts[] = {
 			Widget(WT_CLOSEBOX, INVALID_WIDGET_INDEX, COL_RANGE_DARK_RED),
 		EndContainer(),
 		Widget(WT_PANEL, INVALID_WIDGET_INDEX, COL_RANGE_DARK_RED),
+		Intermediate(2, 1),
+			Widget(WT_CENTERED_TEXT, GIW_STATUS, COL_RANGE_DARK_RED), SetData(STR_ARG1, STR_NULL),
 			Intermediate(8, 2), SetPadding(2, 2, 2, 2),
 				Widget(WT_LEFT_TEXT, INVALID_WIDGET_INDEX, COL_RANGE_DARK_RED), SetData(GUI_GUEST_INFO_MONEY, STR_NULL),
 				Widget(WT_RIGHT_TEXT, GIW_MONEY, COL_RANGE_DARK_RED), SetData(STR_ARG1, STR_NULL),
@@ -92,6 +95,10 @@ void GuestInfoWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 	switch (wid_num) {
 		case GIW_TITLEBAR:
 			_str_params.SetUint8(1, (uint8 *)this->guest->GetName());
+			break;
+
+		case GIW_STATUS:
+			_str_params.SetUint8(1, this->guest->GetStatus());
 			break;
 
 		case GIW_MONEY:

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -684,7 +684,10 @@ void SpriteCollector::CollectVoxel(const Voxel *voxel, const XYZPoint16 &voxel_p
 	}
 
 	/* Add voxel objects (persons, ride cars, etc). */
+	/* Sprites on the bottom part of a steep slope need to be drawn at a higher Z layer to prevent the top slope part obscuring them. */
 	const VoxelObject *vo = (voxel == nullptr) ? nullptr : voxel->voxel_objects;
+	const uint32 people_z_pos = (voxel == nullptr || voxel->GetGroundType() == GTP_INVALID ||
+			!IsImplodedSteepSlope(voxel->GetGroundSlope()) || IsImplodedSteepSlopeTop(voxel->GetGroundSlope())) ? voxel_pos.z : (voxel_pos.z + 1);
 	while (vo != nullptr) {
 		const Recolouring *recolour;
 		const ImageData *anim_spr = vo->GetSprite(this->sprites, this->orient, &recolour);
@@ -695,12 +698,12 @@ void SpriteCollector::CollectVoxel(const Voxel *voxel, const XYZPoint16 &voxel_p
 			            north_point.y + this->north_offsets[this->orient].y + y_off);
 
 			DrawData dd;
-			dd.Set(slice, voxel_pos.z, SO_PERSON, anim_spr, pos, recolour);
+			dd.Set(slice, people_z_pos, SO_PERSON, anim_spr, pos, recolour);
 			this->draw_images.insert(dd);
 
 			for (const VoxelObject::Overlay &overlay : vo->GetOverlays(this->sprites, this->orient)) {
 				if (overlay.sprite != nullptr) {
-					dd.Set(slice, voxel_pos.z, SO_PERSON_OVERLAY, overlay.sprite, pos, overlay.recolour);
+					dd.Set(slice, people_z_pos, SO_PERSON_OVERLAY, overlay.sprite, pos, overlay.recolour);
 					this->draw_images.insert(dd);
 				}
 			}


### PR DESCRIPTION
Re #51 & #38 

This fixes a number of crashes and other glitches related to Z positioning of lost people and connection detection of sloped (queue) paths.

There's no Falling animation yet (people are teleported to the surface instantly) but some preparation for one by generalizing the `status` variable for all Persons.