### PR TITLE
Fix errors in text input widget

### DIFF
--- a/src/string_func.cpp
+++ b/src/string_func.cpp
@@ -178,6 +178,37 @@ int EncodeUtf8Char(uint32 codepoint, uint8 *dest)
 }
 
 /**
+ * Find the previous character in the given string, skipping over multi-byte characters.
+ * @param data String to work with.
+ * @param pos Index in the string to start searching from.
+ * @return The previous character's index.
+ */
+size_t GetPrevChar(const uint8 *data, size_t pos)
+{
+	if (pos == 0) return 0;
+	do {
+		pos--;
+	} while (pos > 0 && (data[pos] & 0xc0) == 0x80);
+	return pos;
+}
+
+/**
+ * Find the next character in the given string, skipping over multi-byte characters.
+ * @param data String to work with.
+ * @param pos Index in the string to start searching from.
+ * @return The next character's index.
+ */
+size_t GetNextChar(const uint8 *data, size_t pos)
+{
+	const size_t length = StrBytesLength(data);
+	if (pos >= length) return length;
+	do {
+		pos++;
+	} while (pos < length && (data[pos] & 0xc0) == 0x80);
+	return pos;
+}
+
+/**
  * Are the two strings equal?
  * @param s1 First string to compare.
  * @param s2 Second string to compare.

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -19,6 +19,8 @@ size_t StrBytesLength(const uint8 *txt);
 
 int DecodeUtf8Char(const uint8 *data, size_t length, uint32 *codepoint);
 int EncodeUtf8Char(uint32 codepoint, uint8 *dest = nullptr);
+size_t GetPrevChar(const uint8 *data, size_t pos);
+size_t GetNextChar(const uint8 *data, size_t pos);
 
 bool StrEqual(const uint8 *s1, const uint8 *s2);
 bool StrEndsWith(const char *str, const char *end, bool case_sensitive);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -361,6 +361,8 @@ bool VideoSystem::HandleEvent()
 				case SDLK_LEFT:      return HandleKeyInput(WMKC_CURSOR_LEFT, nullptr);
 				case SDLK_RIGHT:     return HandleKeyInput(WMKC_CURSOR_RIGHT, nullptr);
 				case SDLK_DOWN:      return HandleKeyInput(WMKC_CURSOR_DOWN, nullptr);
+				case SDLK_HOME:      return HandleKeyInput(WMKC_CURSOR_HOME, nullptr);
+				case SDLK_END:       return HandleKeyInput(WMKC_CURSOR_END, nullptr);
 				case SDLK_ESCAPE:    return HandleKeyInput(WMKC_CANCEL, nullptr);
 				case SDLK_DELETE:    return HandleKeyInput(WMKC_DELETE, nullptr);
 				case SDLK_BACKSPACE: return HandleKeyInput(WMKC_BACKSPACE, nullptr);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -635,32 +635,78 @@ void TextInputWidget::SetText(uint8 *text)
 	this->buffer.reset(text);
 	this->text_length = strlen(reinterpret_cast<const char*>(text));
 	this->cursor_pos = std::min(this->cursor_pos, this->text_length);
+	this->MarkDirty(this->cached_window_base);
+}
+
+/**
+ * Check whether a character is an extended UTF-8 character.
+ * @param c Character to check.
+ * @return The character is extended.
+ */
+static inline bool IsUtf8Extended(uint8 c) {
+	return (c & 0xc0) == 0x80;
 }
 
 bool TextInputWidget::OnKeyEvent(WmKeyCode key_code, const uint8 *symbol)
 {
 	switch (key_code) {
 		case WMKC_CURSOR_LEFT:
-			if (this->cursor_pos > 0) this->cursor_pos--;
+			if (this->cursor_pos > 0) {
+				do {
+					this->cursor_pos--;
+				} while (this->cursor_pos > 0 && IsUtf8Extended(this->buffer[this->cursor_pos]));
+				this->MarkDirty(this->cached_window_base);
+			}
 			return true;
 		case WMKC_CURSOR_RIGHT:
-			if (this->cursor_pos < this->text_length) this->cursor_pos++;
+			if (this->cursor_pos < this->text_length) {
+				do {
+					this->cursor_pos++;
+				} while (this->cursor_pos < this->text_length && IsUtf8Extended(this->buffer[this->cursor_pos]));
+				this->MarkDirty(this->cached_window_base);
+			}
+			return true;
+		case WMKC_CURSOR_HOME:
+			this->cursor_pos = 0;
+			this->MarkDirty(this->cached_window_base);
+			return true;
+		case WMKC_CURSOR_END:
+			this->cursor_pos = this->text_length;
+			this->MarkDirty(this->cached_window_base);
 			return true;
 
 		case WMKC_BACKSPACE:
 			if (this->cursor_pos > 0) {
-				uint8* newtext = new uint8[this->text_length];
-				strncpy(reinterpret_cast<char*>(newtext), reinterpret_cast<const char*>(this->GetText()), this->cursor_pos - 1);
-				strcpy (reinterpret_cast<char*>(newtext) + this->cursor_pos - 1, reinterpret_cast<const char*>(this->GetText()) + this->cursor_pos);
-				this->cursor_pos--;
+				uint8 nr_chars_to_delete = 1;
+				for (unsigned i = this->cursor_pos - 1; i > 0; i--) {
+					if (IsUtf8Extended(this->buffer[i])) {
+						nr_chars_to_delete++;
+					} else {
+						break;
+					}
+				}
+
+				uint8 *newtext = new uint8[this->text_length + 1 - nr_chars_to_delete];
+				strncpy(reinterpret_cast<char*>(newtext), reinterpret_cast<const char*>(this->GetText()), this->cursor_pos - nr_chars_to_delete);
+				strcpy (reinterpret_cast<char*>(newtext) + this->cursor_pos - nr_chars_to_delete, reinterpret_cast<const char*>(this->GetText()) + this->cursor_pos);
+				this->cursor_pos -= nr_chars_to_delete;
 				this->SetText(newtext);
 			}
 			return true;
 		case WMKC_DELETE:
 			if (this->cursor_pos < this->text_length) {
-				uint8* newtext = new uint8[this->text_length];
+				uint8 nr_chars_to_delete = 1;
+				for (unsigned i = this->cursor_pos + 1; i < this->text_length; i++) {
+					if (IsUtf8Extended(this->buffer[i])) {
+						nr_chars_to_delete++;
+					} else {
+						break;
+					}
+				}
+
+				uint8 *newtext = new uint8[this->text_length + 1 - nr_chars_to_delete];
 				strncpy(reinterpret_cast<char*>(newtext), reinterpret_cast<const char*>(this->GetText()), this->cursor_pos);
-				strcpy (reinterpret_cast<char*>(newtext) + this->cursor_pos, reinterpret_cast<const char*>(this->GetText()) + this->cursor_pos + 1);
+				strcpy (reinterpret_cast<char*>(newtext) + this->cursor_pos, reinterpret_cast<const char*>(this->GetText()) + this->cursor_pos + nr_chars_to_delete);
 				this->SetText(newtext);
 			}
 			return true;
@@ -669,7 +715,7 @@ bool TextInputWidget::OnKeyEvent(WmKeyCode key_code, const uint8 *symbol)
 			const size_t off = strlen(reinterpret_cast<const char*>(symbol));
 			if (off == 0) break;
 
-			uint8* newtext = new uint8[this->text_length + off + 1];
+			uint8 *newtext = new uint8[this->text_length + off + 1];
 			strncpy(reinterpret_cast<char*>(newtext), reinterpret_cast<const char*>(this->GetText()), this->cursor_pos);
 			strcpy (reinterpret_cast<char*>(newtext) + this->cursor_pos, reinterpret_cast<const char*>(symbol));
 			strcpy (reinterpret_cast<char*>(newtext) + this->cursor_pos + off, reinterpret_cast<const char*>(this->GetText()) + this->cursor_pos);
@@ -685,6 +731,7 @@ bool TextInputWidget::OnKeyEvent(WmKeyCode key_code, const uint8 *symbol)
 
 void TextInputWidget::Draw(const GuiWindow *w)
 {
+	this->cached_window_base = w->rect.base;
 	Rectangle32 r = this->pos;
 	r.base += w->rect.base;
 	_video.FillRectangle(r, _palette[COL_SERIES_START + (this->colour - 1) * COL_SERIES_LENGTH + 2]);

--- a/src/widget.h
+++ b/src/widget.h
@@ -236,6 +236,7 @@ private:
 	size_t cursor_pos;                ///< Position of the cursor in the text.
 	int value_width;                  ///< Width of the image or the string.
 	int value_height;                 ///< Height of the image or the string.
+	Point32 cached_window_base;       ///< This widget's last window base position.
 };
 
 /**

--- a/src/window_constants.h
+++ b/src/window_constants.h
@@ -100,6 +100,8 @@ enum WmKeyCode {
 	WMKC_CURSOR_LEFT,  ///< Left arrow key is pressed.
 	WMKC_CURSOR_RIGHT, ///< Right arrow key is pressed.
 	WMKC_CURSOR_DOWN,  ///< Down arrow key is pressed.
+	WMKC_CURSOR_HOME,  ///< Home key is pressed.
+	WMKC_CURSOR_END,   ///< End key is pressed.
 	WMKC_BACKSPACE,    ///< Backspace is pressed.
 	WMKC_DELETE,       ///< Delete is pressed.
 	WMKC_CANCEL,       ///< Cancel is pressed.


### PR DESCRIPTION
Fix handling of multi-byte characters like äöüß, repaint the widget after all changes, and add <kbd>Home</kbd>/<kbd>End</kbd> keys handling.