### PR TITLE
Refactor `uint8*` to `std::string` or `char*`

### DIFF
--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -51,7 +51,7 @@ void CoasterRemoveWindow::OnClick(WidgetNumber number, const Point16 &pos)
 
 void CoasterRemoveWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 {
-	if (wid_num == ERW_MESSAGE) _str_params.SetUint8(1, (uint8 *)this->ci->name.get());
+	if (wid_num == ERW_MESSAGE) _str_params.SetText(1, this->ci->name);
 }
 
 /**
@@ -366,7 +366,7 @@ void CoasterInstanceWindow::SetWidgetStringParameters(WidgetNumber wid_num) cons
 {
 	switch (wid_num) {
 		case CIW_TITLEBAR:
-			_str_params.SetUint8(1, (uint8 *)this->ci->name.get());
+			_str_params.SetText(1, this->ci->name);
 			break;
 
 		case CIW_MONTHLY_COST:
@@ -403,9 +403,9 @@ void CoasterInstanceWindow::SetWidgetStringParameters(WidgetNumber wid_num) cons
 			if (this->ci->broken) {
 				_str_params.SetStrID(1, GUI_RIDE_MANAGER_BROKEN_DOWN);
 			} else {
-				snprintf(text_buffer, lengthof(text_buffer), reinterpret_cast<const char*>(_language.GetText(GUI_RIDE_MANAGER_RELIABILITY)),
+				snprintf(text_buffer, lengthof(text_buffer), _language.GetText(GUI_RIDE_MANAGER_RELIABILITY).c_str(),
 						this->ci->reliability / 100.0);
-				_str_params.SetUint8(1, reinterpret_cast<uint8*>(text_buffer));
+				_str_params.SetText(1, text_buffer);
 			}
 			break;
 
@@ -525,7 +525,7 @@ void CoasterInstanceWindow::OnClick(WidgetNumber widget, const Point16 &pos)
 		case CIW_CHOOSE_ENTRANCE: {
 			DropdownList itemlist;
 			for (const auto &eetype : _rides_manager.entrances) {
-				_str_params.SetUint8(1, _language.GetText(eetype->name));
+				_str_params.SetText(1, _language.GetText(eetype->name));
 				itemlist.push_back(DropdownItem(STR_ARG1));
 			}
 			this->ShowDropdownMenu(widget, itemlist, this->ci->entrance_type, COL_RANGE_DARK_RED);
@@ -534,7 +534,7 @@ void CoasterInstanceWindow::OnClick(WidgetNumber widget, const Point16 &pos)
 		case CIW_CHOOSE_EXIT: {
 			DropdownList itemlist;
 			for (const auto &eetype : _rides_manager.exits) {
-				_str_params.SetUint8(1, _language.GetText(eetype->name));
+				_str_params.SetText(1, _language.GetText(eetype->name));
 				itemlist.push_back(DropdownItem(STR_ARG1));
 			}
 			this->ShowDropdownMenu(widget, itemlist, this->ci->exit_type, COL_RANGE_DARK_RED);
@@ -1018,7 +1018,7 @@ void CoasterBuildWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 {
 	switch (wid_num) {
 		case CCW_TITLEBAR:
-			_str_params.SetUint8(1, (uint8 *)this->ci->name.get());
+			_str_params.SetText(1, this->ci->name);
 			break;
 	}
 }

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -80,6 +80,16 @@ ConfigSection::~ConfigSection() {
 }
 
 /**
+ * Check if this section contains an element with the specified key.
+ * @param key Value of the key to look for (case sensitive).
+ * @return An item with this key exists.
+ */
+bool ConfigSection::HasItem(const std::string &key) const
+{
+	return this->items.count(key) > 0;
+}
+
+/**
  * Get an item from a section if it exists.
  * @param key Value of the key to look for (case sensitive).
  * @return The associated item if it exists, else \c nullptr.
@@ -142,8 +152,9 @@ ConfigFile::ConfigFile(const std::string &fname) : filename(fname)
 			if (*line2 == ']') {
 				*line2 = '\0';
 				const std::string sect_name(StripWhitespace(line + 1, line2));
-				if (this->sections.count(sect_name) == 0) this->sections.emplace(sect_name,
-						std::unique_ptr<ConfigSection>(new ConfigSection(*this, sect_name)));
+				if (this->sections.count(sect_name) == 0) {
+					this->sections.emplace(sect_name, std::unique_ptr<ConfigSection>(new ConfigSection(*this, sect_name)));
+				}
 				current_sect = this->sections.at(sect_name).get();
 			}
 			continue;
@@ -169,6 +180,18 @@ ConfigFile::ConfigFile(const std::string &fname) : filename(fname)
 }
 
 /**
+ * Check if a section in this config file contains an element with the specified key.
+ * @param sect_name The section in which to look for the key (case sensitive).
+ * @param key Value of the key to look for (case sensitive).
+ * @return An item with this key exists in this section.
+ */
+bool ConfigFile::HasValue(const std::string &sect_name, const std::string &key) const
+{
+	ConfigSection *s = this->GetSection(sect_name);
+	return s != nullptr && s->HasItem(key);
+}
+
+/**
  * Get a section from the configuration file.
  * @param sect_name Name of the section (case sensitive).
  * @return The section with the give name if it exists, else \c nullptr.
@@ -183,7 +206,7 @@ const ConfigSection *ConfigFile::GetSection(const std::string &sect_name) const
  * Get an item value from the configuration file.
  * @param sect_name Name of the section (case sensitive).
  * @param key Name of the key (case sensitive).
- * @return The associated value if it exists, else \c nullptr.
+ * @return The associated value if it exists, else \c "".
  */
 std::string ConfigFile::GetValue(const std::string &sect_name, const std::string &key) const
 {

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -14,20 +14,11 @@
 
 /**
  * Construct a key/value item.
- * @param key Key text.
  * @param value Value text.
- * @note Key and value texts get copied during construction.
  */
-ConfigItem::ConfigItem(const char *key, const char *value)
+ConfigItem::ConfigItem(const std::string &value)
 {
-	this->key = StrDup(key);
-	this->value = StrDup(value);
-}
-
-ConfigItem::~ConfigItem()
-{
-	delete[] this->key;
-	delete[] this->value;
+	this->value = value;
 }
 
 /**
@@ -36,33 +27,15 @@ ConfigItem::~ConfigItem()
  */
 int ConfigItem::GetNum() const
 {
-	int val = 0;
-	int length = 0;
-	const char *p = this->value;
-
-	while (*p >= '0' && *p <= '9') {
-		val = val * 10 + (*p - '0');
-		length++;
-		p++;
+	try {
+		size_t position;
+		const int result = stoi(this->value, &position);
+		if (position != this->value.size()) return -1;
+		return result;
+	} catch (...) {
+		/* Not a valid integer string. */
+		return -1;
 	}
-	if (*p != '\0' || length > 8) return -1; // Bad integer number
-	return val;
-}
-
-/**
- * Construct a named section.
- * @param sect_name Name of the new section.
- * @note Section name gets copied during construction.
- */
-ConfigSection::ConfigSection(const char *sect_name)
-{
-	this->sect_name = StrDup(sect_name);
-	this->items.clear();
-}
-
-ConfigSection::~ConfigSection()
-{
-	delete[] this->sect_name;
 }
 
 /**
@@ -70,42 +43,10 @@ ConfigSection::~ConfigSection()
  * @param key Value of the key to look for (case sensitive).
  * @return The associated item if it exists, else \c nullptr.
  */
-const ConfigItem *ConfigSection::GetItem(const char *key) const
+const ConfigItem *ConfigSection::GetItem(const std::string &key) const
 {
-	for (const auto &iter : this->items) {
-		if (!strcmp(iter->key, key)) return iter;
-	}
-	return nullptr;
-}
-
-ConfigFile::ConfigFile()
-{
-	this->Clear();
-}
-
-ConfigFile::~ConfigFile()
-{
-	this->Clear();
-}
-
-/** Clean the config file. */
-void ConfigFile::Clear()
-{
-	for (const auto &sect : this->sections) {
-		for (const auto &item : sect->items) delete item;
-		delete sect;
-	}
-}
-
-/**
- * Is the given character a white space character?
- * @param k Provided character.
- * @return The provided character is a white space character.
- * @ingroup fileio_group
- */
-static bool IsSpace(char k)
-{
-	return k == ' ' || k == '\r' || k == '\n' || k == '\t';
+	const auto it = this->items.find(key);
+	return it == this->items.end() ? nullptr : it->second.get();
 }
 
 /**
@@ -125,52 +66,31 @@ static char *StripWhitespace(char *first, char *last = nullptr)
 
 	assert(*last == '\0');
 
-	while (first < last && IsSpace(*first)) first++;
-	while (last > first + 1 && IsSpace(last[-1])) last--;
+	while (first < last && isspace(*first)) first++;
+	while (last > first + 1 && isspace(last[-1])) last--;
 	*last = '\0';
 	return first;
 }
 
 /**
- * Try to find the configuration file from the list of directories, and load it if found.
- * @param dir_list \c nullptr terminated list of directories to try.
- * @param fname Filename to look for.
- * @return Loading succeeded.
- */
-bool ConfigFile::LoadFromDirectoryList(const char **dir_list, const char *fname)
-{
-	while (*dir_list != nullptr) {
-		std::string fpath = std::string(*dir_list) + '/' + fname;
-		if (PathIsFile(fpath.c_str()) && this->Load(fpath.c_str())) {
-			return true;
-		}
-		dir_list++;
-	}
-	return false;
-}
-
-/**
  * Load a config file.
  * @param fname Filename to load.
- * @return Loading succeeded.
  * @todo [easy] Eliminate duplicate config sections.
  * @todo [easy] Strip whitespace around section names.
  */
-bool ConfigFile::Load(const char *fname)
+ConfigFile::ConfigFile(const std::string &fname)
 {
 	ConfigSection *current_sect = nullptr;
 
-	this->Clear();
-
-	FILE *fp = fopen(fname, "rb");
-	if (fp == nullptr) return false;
+	FILE *fp = fopen(fname.c_str(), "rb");
+	if (fp == nullptr) return;
 
 	for (;;) {
 		char buffer[256];
 		char *line = fgets(buffer, lengthof(buffer), fp);
 		if (line == nullptr) break;
 
-		while (*line != '\0' && IsSpace(*line)) line++;
+		while (*line != '\0' && isspace(*line)) line++;
 		if (*line == '\0' || *line == ';') continue; // Silently skip empty lines or comment lines.
 
 		if (*line == '[') {
@@ -179,9 +99,9 @@ bool ConfigFile::Load(const char *fname)
 			while (*line2 != '\0' && *line2 != ']') line2++;
 			if (*line2 == ']') {
 				*line2 = '\0';
-				/* XXX Look for an existing config section? */
-				current_sect = new ConfigSection(StripWhitespace(line + 1, line2));
-				this->sections.push_front(current_sect);
+				const std::string sect_name(StripWhitespace(line + 1, line2));
+				if (this->sections.count(sect_name) == 0) this->sections.emplace(sect_name, std::unique_ptr<ConfigSection>(new ConfigSection));
+				current_sect = this->sections.at(sect_name).get();
 			}
 			continue;
 		}
@@ -191,18 +111,18 @@ bool ConfigFile::Load(const char *fname)
 		/* Key/value line. */
 		char *line2 = line;
 		while (*line2 != '\0' && *line2 != '=') line2++;
-		ConfigItem *item;
+		std::string key, value;
 		if (*line2 == '=') {
 			*line2 = '\0';
-			item = new ConfigItem(StripWhitespace(line, line2), StripWhitespace(line2 + 1));
+			key = StripWhitespace(line, line2);
+			value = StripWhitespace(line2 + 1);
 		} else {
 			/* No value. */
-			item = new ConfigItem(StripWhitespace(line, line2), "");
+			key = StripWhitespace(line, line2);
 		}
-		current_sect->items.push_front(item);
+		current_sect->items.emplace(key, std::unique_ptr<ConfigItem>(new ConfigItem(value)));
 	}
 	fclose(fp);
-	return true;
 }
 
 /**
@@ -210,12 +130,10 @@ bool ConfigFile::Load(const char *fname)
  * @param sect_name Name of the section (case sensitive).
  * @return The section with the give name if it exists, else \c nullptr.
  */
-const ConfigSection *ConfigFile::GetSection(const char *sect_name) const
+const ConfigSection *ConfigFile::GetSection(const std::string &sect_name) const
 {
-	for (const auto &iter : this->sections) {
-		if (!strcmp(iter->sect_name, sect_name)) return iter;
-	}
-	return nullptr;
+	const auto it = this->sections.find(sect_name);
+	return it == this->sections.end() ? nullptr : it->second.get();
 }
 
 /**
@@ -224,13 +142,13 @@ const ConfigSection *ConfigFile::GetSection(const char *sect_name) const
  * @param key Name of the key (case sensitive).
  * @return The associated value if it exists, else \c nullptr.
  */
-const char *ConfigFile::GetValue(const char *sect_name, const char *key) const
+std::string ConfigFile::GetValue(const std::string &sect_name, const std::string &key) const
 {
 	const ConfigSection *sect = this->GetSection(sect_name);
-	if (sect == nullptr) return nullptr;
+	if (sect == nullptr) return std::string();
 
 	const ConfigItem *item = sect->GetItem(key);
-	if (item == nullptr) return nullptr;
+	if (item == nullptr) return std::string();
 	return item->value;
 }
 
@@ -240,7 +158,7 @@ const char *ConfigFile::GetValue(const char *sect_name, const char *key) const
  * @param key Name of the key (case sensitive).
  * @return The associated number if it exists, else \c -1.
  */
-int ConfigFile::GetNum(const char *sect_name, const char *key) const
+int ConfigFile::GetNum(const std::string &sect_name, const std::string &key) const
 {
 	const ConfigSection *sect = this->GetSection(sect_name);
 	if (sect == nullptr) return -1;

--- a/src/config_reader.cpp
+++ b/src/config_reader.cpp
@@ -187,7 +187,7 @@ ConfigFile::ConfigFile(const std::string &fname) : filename(fname)
  */
 bool ConfigFile::HasValue(const std::string &sect_name, const std::string &key) const
 {
-	ConfigSection *s = this->GetSection(sect_name);
+	const ConfigSection *s = this->GetSection(sect_name);
 	return s != nullptr && s->HasItem(key);
 }
 

--- a/src/config_reader.h
+++ b/src/config_reader.h
@@ -14,17 +14,26 @@
 #include <memory>
 #include <string>
 
+class ConfigSection;
+class ConfigFile;
+
 /**
  * Item in a configuration file (a key/value pair).
  * @ingroup fileio_group
  */
 class ConfigItem {
 public:
-	explicit ConfigItem(const std::string &value);
+	explicit ConfigItem(const ConfigSection &section, const std::string &key, const std::string &value);
+	~ConfigItem();
 
 	int GetNum() const;
+	const std::string &GetString() const;
 
-	std::string value; ///< Value text.
+private:
+	const ConfigSection &section;  ///< Section backlink.
+	const std::string key;         ///< Key text.
+	const std::string value;       ///< Value text.
+	mutable bool used;             ///< Whether this value has ever been read from.
 };
 
 /**
@@ -33,7 +42,17 @@ public:
  */
 class ConfigSection {
 public:
+	explicit ConfigSection(const ConfigFile &file, const std::string &name);
+	~ConfigSection();
+
 	const ConfigItem *GetItem(const std::string &key) const;
+
+	const ConfigFile &file;  ///< Config file backlink.
+	const std::string name;  ///< Section name.
+
+private:
+	friend class ConfigFile;
+	mutable bool used;                                         ///< Whether this section has ever been accessed.
 	std::map<std::string, std::unique_ptr<ConfigItem>> items;  ///< Items of the section.
 };
 
@@ -49,7 +68,8 @@ public:
 	std::string GetValue(const std::string &sect_name, const std::string &key) const;
 	int GetNum(const std::string &sect_name, const std::string &key) const;
 
-	std::map<std::string, std::unique_ptr<ConfigSection>> sections; ///< Sections of the configuration file.
+	const std::string filename;                                      ///< Name of the config file.
+	std::map<std::string, std::unique_ptr<ConfigSection>> sections;  ///< Sections of the configuration file.
 };
 
 #endif

--- a/src/config_reader.h
+++ b/src/config_reader.h
@@ -45,6 +45,7 @@ public:
 	explicit ConfigSection(const ConfigFile &file, const std::string &name);
 	~ConfigSection();
 
+	bool HasItem(const std::string &key) const;
 	const ConfigItem *GetItem(const std::string &key) const;
 
 	const ConfigFile &file;  ///< Config file backlink.
@@ -65,6 +66,8 @@ public:
 	explicit ConfigFile(const std::string &fname);
 
 	const ConfigSection *GetSection(const std::string &name) const;
+
+	bool HasValue(const std::string &sect_name, const std::string &key) const;
 	std::string GetValue(const std::string &sect_name, const std::string &key) const;
 	int GetNum(const std::string &sect_name, const std::string &key) const;
 

--- a/src/config_reader.h
+++ b/src/config_reader.h
@@ -10,7 +10,9 @@
 #ifndef CONFIG_READER_H
 #define CONFIG_READER_H
 
-#include <forward_list>
+#include <map>
+#include <memory>
+#include <string>
 
 /**
  * Item in a configuration file (a key/value pair).
@@ -18,20 +20,12 @@
  */
 class ConfigItem {
 public:
-	ConfigItem(const char *key, const char *value);
-	~ConfigItem();
+	explicit ConfigItem(const std::string &value);
 
 	int GetNum() const;
 
-	const char *key;   ///< Key text.
-	const char *value; ///< Value text.
+	std::string value; ///< Value text.
 };
-
-/**
- * A list of items.
- * @ingroup fileio_group
- */
-typedef std::forward_list<ConfigItem *> ConfigItemList;
 
 /**
  * Section in a configuration file (a set of related items).
@@ -39,20 +33,9 @@ typedef std::forward_list<ConfigItem *> ConfigItemList;
  */
 class ConfigSection {
 public:
-	ConfigSection(const char *sect_name);
-	~ConfigSection();
-
-	const ConfigItem *GetItem(const char *key) const;
-
-	const char *sect_name; ///< Name of the section.
-	ConfigItemList items;  ///< Items of the section.
+	const ConfigItem *GetItem(const std::string &key) const;
+	std::map<std::string, std::unique_ptr<ConfigItem>> items;  ///< Items of the section.
 };
-
-/**
- * A list of sections.
- * @ingroup fileio_group
- */
-typedef std::forward_list<ConfigSection *> ConfigSectionList;
 
 /**
  * A configuration file.
@@ -60,18 +43,13 @@ typedef std::forward_list<ConfigSection *> ConfigSectionList;
  */
 class ConfigFile {
 public:
-	ConfigFile();
-	~ConfigFile();
+	explicit ConfigFile(const std::string &fname);
 
-	void Clear();
-	bool Load(const char *fname);
-	bool LoadFromDirectoryList(const char **dir_list, const char *fname);
+	const ConfigSection *GetSection(const std::string &name) const;
+	std::string GetValue(const std::string &sect_name, const std::string &key) const;
+	int GetNum(const std::string &sect_name, const std::string &key) const;
 
-	const ConfigSection *GetSection(const char *name) const;
-	const char *GetValue(const char *sect_name, const char *key) const;
-	int GetNum(const char *sect_name, const char *key) const;
-
-	ConfigSectionList sections; ///< Sections of the configuration file.
+	std::map<std::string, std::unique_ptr<ConfigSection>> sections; ///< Sections of the configuration file.
 };
 
 #endif

--- a/src/dropdown.cpp
+++ b/src/dropdown.cpp
@@ -17,9 +17,8 @@
  * @param strid StringID to store.
  * @pre String parameters must be set for this string.
  */
-DropdownItem::DropdownItem(StringID strid)
+DropdownItem::DropdownItem(StringID strid) : str(DrawText(strid))
 {
-	DrawText(strid, this->str, lengthof(this->str));
 }
 
 /**

--- a/src/freerct.cpp
+++ b/src/freerct.cpp
@@ -145,8 +145,6 @@ int freerct_main(int argc, char **argv)
 	/* Create the data directory on startup if it did not exist yet. */
 	MakeDirectory(freerct_userdata_prefix());
 
-	ConfigFile cfg_file;
-
 	/* Load RCD files. */
 	InitImageStorage();
 	_rcd_collection.ScanDirectories();
@@ -159,24 +157,19 @@ int freerct_main(int argc, char **argv)
 		return 1;
 	}
 
-	{
-		std::unique_ptr<DirectoryReader> dr(MakeDirectoryReader());
-		std::string path = freerct_userdata_prefix();
-		path += dr->dir_sep;
-		path += "freerct.cfg";
-		cfg_file.Load(path.c_str());
-	}
+	std::unique_ptr<DirectoryReader> dr(MakeDirectoryReader());
+	std::string cfg_file_path = freerct_userdata_prefix();
+	cfg_file_path += dr->dir_sep;
+	cfg_file_path += "freerct.cfg";
+	ConfigFile cfg_file(cfg_file_path);
 
-	const char *font_path = cfg_file.GetValue("font", "medium-path");
+	std::string font_path = cfg_file.GetValue("font", "medium-path");
 	int font_size = cfg_file.GetNum("font", "medium-size");
-	/* Use default values if no font has been set. */
-	std::string font_path_fallback;
-	if (font_path == nullptr) {
-		font_path_fallback = FindDataFile("data/font/Ubuntu-L.ttf");
-		font_path = font_path_fallback.c_str();
-	}
-	if (font_size < 1) font_size = 15;
 	if (cfg_file.GetNum("saveloading", "auto-resave") > 0) _automatically_resave_files = true;
+
+	/* Use default values if no font has been set. */
+	if (font_path.empty()) font_path = FindDataFile("data/font/Ubuntu-L.ttf");
+	if (font_size < 1) font_size = 15;
 
 	/* Overwrite the default language settings if the user specified a custom language on the command line or in the config file. */
 	bool language_set = false;
@@ -193,12 +186,12 @@ int freerct_main(int argc, char **argv)
 		}
 	}
 	if (!language_set) {
-		const char *language = cfg_file.GetValue("language", "language");  // The pointer is owned by cfg_file.
-		if (language != nullptr) {
-			int index = GetLanguageIndex(language);
+		preferred_language = cfg_file.GetValue("language", "language");  // The pointer is owned by cfg_file.
+		if (!preferred_language.empty()) {
+			int index = GetLanguageIndex(preferred_language.c_str());
 			if (index < 0) {
-				fprintf(stderr, "The language '%s' set in the configuration file (freerct.cfg) is not known.\n", language);
-				const char *similar = GetSimilarLanguage(language);
+				fprintf(stderr, "The language '%s' set in the configuration file (freerct.cfg) is not known.\n", preferred_language.c_str());
+				const char *similar = GetSimilarLanguage(preferred_language);
 				if (similar != nullptr) fprintf(stderr, "Did you perhaps mean '%s'?\n", similar);
 				fprintf(stderr, "Type 'freerct --help' for a list of all supported languages.\n");
 			} else {
@@ -208,7 +201,7 @@ int freerct_main(int argc, char **argv)
 	}
 
 	/* Initialize video. */
-	std::string err = _video.Initialize(font_path, font_size);
+	std::string err = _video.Initialize(font_path.c_str(), font_size);
 	if (!err.empty()) {
 		fprintf(stderr, "Failed to initialize window or the font (%s), aborting\n", err.c_str());
 		return 1;

--- a/src/gamecontrol.cpp
+++ b/src/gamecontrol.cpp
@@ -338,7 +338,6 @@ bool BestErrorMessageReason::CheckActionAllowed(const CheckActionType type, cons
 
 /** Assigns every error message a priority, to decide which one should be shown when multiple are applicable. */
 static const std::map<StringID, int> ERROR_MESSAGE_REASON_PRIORITIES = {
-	{STR_EMPTY,                        0},
 	{STR_NULL,                         1},
 	{GUI_ERROR_MESSAGE_BAD_LOCATION,  10},
 	{GUI_ERROR_MESSAGE_UNOWNED_LAND,  20},

--- a/src/gentle_thrill_ride_gui.cpp
+++ b/src/gentle_thrill_ride_gui.cpp
@@ -51,7 +51,7 @@ void GentleThrillRideRemoveWindow::OnClick(WidgetNumber number, const Point16 &p
 
 void GentleThrillRideRemoveWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 {
-	if (wid_num == ERW_MESSAGE) _str_params.SetUint8(1, (uint8 *)this->si->name.get());
+	if (wid_num == ERW_MESSAGE) _str_params.SetText(1, this->si->name);
 }
 
 /**
@@ -287,8 +287,8 @@ void GentleThrillRideManagerWindow::SetWidgetStringParameters(WidgetNumber wid_n
 {
 	switch (wid_num) {
 		case GTRMW_TITLEBAR:
-			_str_params.SetUint8(1, _language.GetText(this->ride->GetKind() == RTK_GENTLE ? GUI_GENTLE_RIDES_MANAGER_TITLE : GUI_THRILL_RIDES_MANAGER_TITLE));
-			_str_params.SetUint8(2, this->ride->name.get());
+			_str_params.SetText(1, _language.GetText(this->ride->GetKind() == RTK_GENTLE ? GUI_GENTLE_RIDES_MANAGER_TITLE : GUI_THRILL_RIDES_MANAGER_TITLE));
+			_str_params.SetText(2, this->ride->name);
 			break;
 
 		case GTRMW_MONTHLY_COST:
@@ -308,9 +308,9 @@ void GentleThrillRideManagerWindow::SetWidgetStringParameters(WidgetNumber wid_n
 			if (this->ride->broken) {
 				_str_params.SetStrID(1, GUI_RIDE_MANAGER_BROKEN_DOWN);
 			} else {
-				snprintf(text_buffer, lengthof(text_buffer), reinterpret_cast<const char*>(_language.GetText(GUI_RIDE_MANAGER_RELIABILITY)),
+				snprintf(text_buffer, lengthof(text_buffer), _language.GetText(GUI_RIDE_MANAGER_RELIABILITY).c_str(),
 						this->ride->reliability / 100.0);
-				_str_params.SetUint8(1, reinterpret_cast<uint8*>(text_buffer));
+				_str_params.SetText(1, text_buffer);
 			}
 			break;
 
@@ -451,7 +451,7 @@ void GentleThrillRideManagerWindow::OnClick(WidgetNumber wid_num, const Point16 
 		case GTRMW_CHOOSE_ENTRANCE: {
 			DropdownList itemlist;
 			for (const auto &eetype : _rides_manager.entrances) {
-				_str_params.SetUint8(1, _language.GetText(eetype->name));
+				_str_params.SetText(1, _language.GetText(eetype->name));
 				itemlist.push_back(DropdownItem(STR_ARG1));
 			}
 			this->ShowDropdownMenu(wid_num, itemlist, this->ride->entrance_type, COL_RANGE_DARK_RED);
@@ -460,7 +460,7 @@ void GentleThrillRideManagerWindow::OnClick(WidgetNumber wid_num, const Point16 
 		case GTRMW_CHOOSE_EXIT: {
 			DropdownList itemlist;
 			for (const auto &eetype : _rides_manager.exits) {
-				_str_params.SetUint8(1, _language.GetText(eetype->name));
+				_str_params.SetText(1, _language.GetText(eetype->name));
 				itemlist.push_back(DropdownItem(STR_ARG1));
 			}
 			this->ShowDropdownMenu(wid_num, itemlist, this->ride->exit_type, COL_RANGE_DARK_RED);

--- a/src/gui_graphics.cpp
+++ b/src/gui_graphics.cpp
@@ -217,7 +217,7 @@ static char *GetSingleLine(char *text, int max_width, int *width)
  */
 void GetMultilineTextSize(StringID strid, int max_width, int *width, int *height)
 {
-	/* \todo This design is ugly. Fix the utility function GetSingleLine to work on std::string with a srart index instead of mutable char* . */
+	/* \todo This design is ugly. Fix the utility function GetSingleLine() to work on std::string with a start index instead of mutable char*. */
 	const std::string buffer = DrawText(strid);
 	std::unique_ptr<char[]> mutable_buffer(new char[buffer.size() + 1]);
 	strcpy(mutable_buffer.get(), buffer.c_str());

--- a/src/gui_graphics.cpp
+++ b/src/gui_graphics.cpp
@@ -144,9 +144,7 @@ void OverlayShaded(const Rectangle32 &rect)
  */
 void DrawString(StringID strid, uint8 colour, int x, int y, int width, Alignment align, bool outline)
 {
-	uint8 buffer[1024]; // Arbitrary limit.
-
-	DrawText(strid, buffer, lengthof(buffer));
+	const std::string buffer = DrawText(strid);
 	/** \todo Reduce the naiviness of this. */
 	if (outline) {
 		_video.BlitText(buffer, MakeRGBA(0, 0, 0, OPAQUE), x + 1, y, width, align);
@@ -166,15 +164,15 @@ void DrawString(StringID strid, uint8 colour, int x, int y, int width, Alignment
  * @param width [out]  Actual width of the text.
  * @return Pointer to the end of the line, points to either a NL or a NUL.
  */
-static uint8 *GetSingleLine(uint8 *text, int max_width, int *width)
+static char *GetSingleLine(char *text, int max_width, int *width)
 {
-	uint8 *start = text;
-	uint8 *best_pos = nullptr;
+	char *start = text;
+	char *best_pos = nullptr;
 	for (;;) {
-		uint8 *current = text;
+		char *current = text;
 		/* Proceed to the first white-space. */
 		while (*current != '\n' && *current != '\0' && *current != ' ') current++;
-		uint8 orig = *current;
+		char orig = *current;
 		*current = '\0';
 		int line_width, line_height;
 		_video.GetTextSize(start, &line_width, &line_height);
@@ -219,13 +217,14 @@ static uint8 *GetSingleLine(uint8 *text, int max_width, int *width)
  */
 void GetMultilineTextSize(StringID strid, int max_width, int *width, int *height)
 {
-	uint8 buffer[1024]; // Arbitrary max size.
-	DrawText(strid, buffer, lengthof(buffer));
+	/* \todo This design is ugly. Fix the utility function GetSingleLine to work on std::string with a srart index instead of mutable char* . */
+	const std::string buffer = DrawText(strid);
+	std::unique_ptr<char[]> mutable_buffer(new char[buffer.size() + 1]);
+	strcpy(mutable_buffer.get(), buffer.c_str());
+	char *text = mutable_buffer.get();
 
 	*width = 0;
 	*height = 0;
-
-	uint8 *text = buffer;
 	for (;;) {
 		int line_width;
 		text = GetSingleLine(text, max_width, &line_width);
@@ -250,16 +249,17 @@ void GetMultilineTextSize(StringID strid, int max_width, int *width, int *height
  */
 bool DrawMultilineString(StringID strid, int x, int y, int max_width, int max_height, uint8 colour)
 {
-	uint8 buffer[1024]; // Arbitrary max size.
-	DrawText(strid, buffer, lengthof(buffer));
+	const std::string buffer = DrawText(strid);
+	std::unique_ptr<char[]> mutable_buffer(new char[buffer.size() + 1]);
+	strcpy(mutable_buffer.get(), buffer.c_str());
+	char *text = mutable_buffer.get();
 
-	uint8 *text = buffer;
 	while (*text != '\0') {
 		if (max_height < _video.GetTextHeight()) return false;
 		max_height -= _video.GetTextHeight();
 
 		int line_width;
-		uint8 *end = GetSingleLine(text, max_width, &line_width);
+		char *end = GetSingleLine(text, max_width, &line_width);
 		if (*end == '\0') {
 			_video.BlitText(text, _palette[colour], x, y, max_width);
 			break;

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -283,7 +283,7 @@ uint16 Language::RegisterStrings(const TextData &td, const char * const names[],
 		this->registered[number] = nullptr;
 		for (uint i = 0; i < td.string_count; i++) {
 			const TextString *ts = td.strings.get() + i;
-			if (ts->name == *str) {
+			if (strcmp(ts->name, *str) == 0) {
 				this->registered[number] = ts;
 				break;
 			}

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -435,7 +435,7 @@ std::string DrawText(StringID strid, StringParameters *params)
 			n = n * 10 + *ptr - '0';
 			ptr++;
 		}
-		if (params != nullptr && n >= 1 && n <= (int)lengthof(params->parms)) {
+		if (params != nullptr && n >= 1 && n <= params->parms.size()) {
 			/* Expand parameter 'n-1'. */
 			switch (params->parms[n - 1].parm_type) {
 				case SPT_NONE:

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -128,13 +128,24 @@ StringParameters::StringParameters()
 }
 
 /**
+ * Ensure that this Parameters object can hold at least a certain number of parameters.
+ * @param num Minimum number of parameters.
+ */
+void StringParameters::ReserveCapacity(const int num)
+{
+	assert(num > 0);
+	if (!this->set_mode) this->Clear();
+	if (this->parms.size() < num) this->parms.resize(num);
+}
+
+/**
  * Mark string parameter \a num as 'unused'.
  * @param num Number of the parameter to set (1-based).
  */
 void StringParameters::SetNone(int num)
 {
+	this->ReserveCapacity(num);
 	num--;
-	assert(num >= 0 && (uint)num < lengthof(this->parms));
 	this->parms[num].parm_type = SPT_NONE;
 }
 
@@ -145,10 +156,8 @@ void StringParameters::SetNone(int num)
  */
 void StringParameters::SetStrID(int num, StringID strid)
 {
-	if (!this->set_mode) this->Clear();
-
+	this->ReserveCapacity(num);
 	num--;
-	assert(num >= 0 && (uint)num < lengthof(this->parms));
 	this->parms[num].parm_type = SPT_STRID;
 	this->parms[num].u.str = strid;
 }
@@ -160,10 +169,8 @@ void StringParameters::SetStrID(int num, StringID strid)
  */
 void StringParameters::SetNumber(int num, int64 number)
 {
-	if (!this->set_mode) this->Clear();
-
+	this->ReserveCapacity(num);
 	num--;
-	assert(num >= 0 && (uint)num < lengthof(this->parms));
 	this->parms[num].parm_type = SPT_NUMBER;
 	this->parms[num].u.number = number;
 }
@@ -175,10 +182,8 @@ void StringParameters::SetNumber(int num, int64 number)
  */
 void StringParameters::SetMoney(int num, const Money &amount)
 {
-	if (!this->set_mode) this->Clear();
-
+	this->ReserveCapacity(num);
 	num--;
-	assert(num >= 0 && (uint)num < lengthof(this->parms));
 	this->parms[num].parm_type = SPT_MONEY;
 	this->parms[num].u.number = (int64)amount;
 }
@@ -190,10 +195,8 @@ void StringParameters::SetMoney(int num, const Money &amount)
  */
 void StringParameters::SetTemperature(int num, int value)
 {
-	if (!this->set_mode) this->Clear();
-
+	this->ReserveCapacity(num);
 	num--;
-	assert(num >= 0 && (uint)num < lengthof(this->parms));
 	this->parms[num].parm_type = SPT_TEMPERATURE;
 	this->parms[num].u.number = value;
 }
@@ -205,33 +208,29 @@ void StringParameters::SetTemperature(int num, int value)
  */
 void StringParameters::SetDate(int num, const Date &date)
 {
-	if (!this->set_mode) this->Clear();
-
+	this->ReserveCapacity(num);
 	num--;
-	assert(num >= 0 && (uint)num < lengthof(this->parms));
 	this->parms[num].parm_type = SPT_DATE;
 	this->parms[num].u.dmy = date.Compress();
 }
 
 /**
- * Mark string parameter \a num to contain a C-style UTF-8 string.
+ * Mark string parameter \a num to contain a UTF-8 string.
  * @param num Number of the parameter to set (1-based).
- * @param text UTF-8 string. Is not released after use.
+ * @param text UTF-8 string.
  */
-void StringParameters::SetUint8(int num, const uint8 *text)
+void StringParameters::SetText(int num, const std::string &text)
 {
-	if (!this->set_mode) this->Clear();
-
+	this->ReserveCapacity(num);
 	num--;
-	assert(num >= 0 && (uint)num < lengthof(this->parms));
-	this->parms[num].parm_type = SPT_UINT8;
-	this->parms[num].u.text = text;
+	this->parms[num].parm_type = SPT_TEXT;
+	this->parms[num].text = text;
 }
 
 /** Clear all data from the parameters. Does not free memory. */
 void StringParameters::Clear()
 {
-	for (uint i = 0; i < lengthof(this->parms); i++) this->SetNone(i + 1);
+	this->parms.clear();
 	this->set_mode = true;
 }
 
@@ -284,7 +283,7 @@ uint16 Language::RegisterStrings(const TextData &td, const char * const names[],
 		this->registered[number] = nullptr;
 		for (uint i = 0; i < td.string_count; i++) {
 			const TextString *ts = td.strings.get() + i;
-			if (!strcmp(*str, ts->name)) {
+			if (ts->name == *str) {
 				this->registered[number] = ts;
 				break;
 			}
@@ -300,23 +299,22 @@ uint16 Language::RegisterStrings(const TextData &td, const char * const names[],
  * @param number string number to get.
  * @return String corresponding to the number (not owned by the caller, so don't free it).
  */
-const uint8 *Language::GetText(StringID number)
+std::string Language::GetText(StringID number)
 {
-	static const uint8 *default_strings[] = {
-		nullptr,              // STR_NULL
-		(const uint8 *)"",    // STR_EMPTY
-		(const uint8 *)"%1%", // STR_ARG1
+	static const std::string default_strings[] = {
+		"",     // STR_NULL
+		"%1%",  // STR_ARG1
 	};
 
 	if (number < lengthof(default_strings)) return default_strings[number];
 
 	if (number < lengthof(this->registered) && this->registered[number] != nullptr) {
-		const uint8 *text = this->registered[number]->GetString();
-		if (*text == '\0') return (const uint8 *)"<empty text>";
+		const std::string &text = this->registered[number]->GetString();
+		if (text.empty()) return "<empty text>";
 		return text;
 	}
 
-	return (const uint8 *)"<Invalid string>";
+	return "<Invalid string>";
 }
 
 /**
@@ -324,28 +322,10 @@ const uint8 *Language::GetText(StringID number)
  * @param lang_index The language to look in.
  * @return The language name.
  */
-const uint8 *Language::GetLanguageName(int lang_index)
+std::string Language::GetLanguageName(int lang_index)
 {
 	assert(lang_index < LANGUAGE_COUNT);
 	return this->registered[GUI_LANGUAGE_NAME]->languages[lang_index];
-}
-
-/**
- * Copy a source string to the destination, if it fits.
- * @param dest [out] Destination address.
- * @param last Last byte of the destination (not written).
- * @param src Source string.
- * @return Updated destination.
- */
-static uint8 *CopyString(uint8 *dest, const uint8 *last, const uint8 *src)
-{
-	if (src == nullptr) return dest;
-	while (*src != '\0' && dest < last) {
-		*dest = *src;
-		dest++;
-		src++;
-	}
-	return dest;
 }
 
 /**
@@ -354,16 +334,16 @@ static uint8 *CopyString(uint8 *dest, const uint8 *last, const uint8 *src)
  * @param size The size of the provided buffer.
  * @param amt The double value to be converted.
  */
-static void MoneyStrFmt(uint8 *dest, size_t size, double amt)
+static void MoneyStrFmt(char *dest, size_t size, double amt)
 {
-	const uint8 *curr_sym = _language.GetText(GUI_MONEY_CURRENCY_SYMBOL);
-	size_t curr_sym_len = StrBytesLength(curr_sym);
+	const std::string curr_sym = _language.GetText(GUI_MONEY_CURRENCY_SYMBOL);
+	size_t curr_sym_len = curr_sym.size();
 
-	const uint8 *tho_sep  = _language.GetText(GUI_MONEY_THOUSANDS_SEPARATOR);
-	size_t tho_sep_len  = StrBytesLength(tho_sep);
+	const std::string tho_sep  = _language.GetText(GUI_MONEY_THOUSANDS_SEPARATOR);
+	size_t tho_sep_len  = tho_sep.size();
 
-	const uint8 *dec_sep  = _language.GetText(GUI_MONEY_DECIMAL_SEPARATOR);
-	size_t dec_sep_len  = StrBytesLength(dec_sep);
+	const std::string dec_sep  = _language.GetText(GUI_MONEY_DECIMAL_SEPARATOR);
+	size_t dec_sep_len  = dec_sep.size();
 
 	std::unique_ptr<char[]> buf(new char[size]);
 
@@ -389,18 +369,18 @@ static void MoneyStrFmt(uint8 *dest, size_t size, double amt)
 	}
 
 	/* Copy currency symbol next */
-	SafeStrncpy(dest + j, curr_sym, curr_sym_len + 1);
+	strncpy(dest + j, curr_sym.c_str(), curr_sym_len + 1);
 	j += curr_sym_len;
 	dest[j++] = buf[curpos++];
 
 	for (uint i = curpos; i < len && j + max_append_size < size; i++) {
 		if (len - i > 3 && (int)(i - comma_start) % 3 == 0) {
-			SafeStrncpy(dest + j, tho_sep, tho_sep_len + 1);
+			strncpy(dest + j, tho_sep.c_str(), tho_sep_len + 1);
 			j += tho_sep_len;
 			dest[j++] = buf[i];
 
 		} else if (buf[i] == '.') { // Decimal separator produced by 'snprintf'.
-			SafeStrncpy(dest + j, dec_sep, dec_sep_len + 1);
+			strncpy(dest + j, dec_sep.c_str(), dec_sep_len + 1);
 			j += dec_sep_len;
 
 		} else {
@@ -414,46 +394,39 @@ static void MoneyStrFmt(uint8 *dest, size_t size, double amt)
 
 /**
  * Convert a temperature in 1/10 degrees Celcius to text.
- * @param dest [out] A provided buffer to write the output into.
- * @param size The size of the provided buffer.
  * @param temp Temperature in 1/10 degrees Celcius to convert.
+ * @return Formatted text.
  */
-static void TemperatureStrFormat(uint8 *dest, size_t size, int temp)
+static std::string TemperatureStrFormat(int temp)
 {
-	static const uint8 SUFFIX[] = {' ', 0xE2, 0x84, 0x83, 0}; // " " + degrees Celcius, U+2103
-
 	temp = ((temp < 0) ? temp - 5 : temp + 5) / 10; // Round to degrees Celcius.
-	int len = snprintf((char *)dest, size, "%d", temp);
-	dest += len;
-	size -= len;
-	if (size >= lengthof(SUFFIX)) StrECpy(dest, dest + size, SUFFIX);
+	static char buffer[64];
+	int len = snprintf(buffer, lengthof(buffer), "%d \u2103", temp);  // " " + degrees Celcius, U+2103
+	return buffer;
 }
 
 /**
  * Draw the string into the supplied buffer.
  * @param strid String number to 'draw'.
- * @param buffer [out] Destination buffer.
- * @param length Length of \a buffer in bytes.
  * @param params String parameter values for the "%n%" patterns.
+ * @return The formatted text.
  */
-void DrawText(StringID strid, uint8 *buffer, uint length, StringParameters *params)
+std::string DrawText(StringID strid, StringParameters *params)
 {
-	static uint8 textbuf[64];
+	static char textbuf[64];
+	std::string buffer;
 
-	const uint8 *txt = _language.GetText(strid);
-	const uint8 *last = buffer + ((int)length - 1);
-	const uint8 *ptr = txt;
+	const std::string txt = _language.GetText(strid);
+	const char *ptr = txt.c_str();
 	for (;;) {
-		while (*ptr != '\0' && *ptr != '%' && buffer < last) {
-			*buffer = *ptr;
-			buffer++;
+		while (*ptr != '\0' && *ptr != '%') {
+			buffer.push_back(*ptr);
 			ptr++;
 		}
-		if (*ptr == '\0' || buffer >= last) break;
+		if (*ptr == '\0') break;
 		ptr++;
 		if (*ptr == '%') {
-			*buffer = '%';
-			buffer++;
+			buffer.push_back(*ptr);
 			ptr++;
 			continue;
 		}
@@ -466,37 +439,34 @@ void DrawText(StringID strid, uint8 *buffer, uint length, StringParameters *para
 			/* Expand parameter 'n-1'. */
 			switch (params->parms[n - 1].parm_type) {
 				case SPT_NONE:
-					buffer = CopyString(buffer, last, (uint8 *)"NONE");
+					buffer += "NONE";
 					break;
 
 				case SPT_STRID:
-					buffer = CopyString(buffer, last, _language.GetText(params->parms[n - 1].u.str));
+					buffer += _language.GetText(params->parms[n - 1].u.str);
 					break;
 
-				case SPT_UINT8:
-					buffer = CopyString(buffer, last, params->parms[n - 1].u.text);
+				case SPT_TEXT:
+					buffer += params->parms[n - 1].text;
 					break;
 
 				case SPT_NUMBER:
-					snprintf((char *)textbuf, lengthof(textbuf), "%lld", params->parms[n - 1].u.number);
-					buffer = CopyString(buffer, last, textbuf);
+					snprintf(textbuf, lengthof(textbuf), "%lld", params->parms[n - 1].u.number);
+					buffer += textbuf;
 					break;
 
 				case SPT_MONEY:
 					MoneyStrFmt(textbuf, lengthof(textbuf), params->parms[n - 1].u.number / 100.0);
-					buffer = CopyString(buffer, last, textbuf);
+					buffer += textbuf;
 					break;
 
 				case SPT_TEMPERATURE:
-					TemperatureStrFormat(textbuf, lengthof(textbuf), params->parms[n - 1].u.number);
-					buffer = CopyString(buffer, last, textbuf);
+					buffer += TemperatureStrFormat(params->parms[n - 1].u.number);
 					break;
 
-				case SPT_DATE: {
-					Date d(params->parms[n - 1].u.dmy);
-					buffer = CopyString(buffer, last, GetDateString(d));
+				case SPT_DATE:
+					buffer += GetDateString(Date(params->parms[n - 1].u.dmy));
 					break;
-				}
 
 				default: NOT_REACHED();
 			}
@@ -505,8 +475,8 @@ void DrawText(StringID strid, uint8 *buffer, uint length, StringParameters *para
 		if (*ptr == '\0') break;
 		ptr++;
 	}
-	*buffer = '\0';
 	if (params != nullptr) params->set_mode = false; // Clean parameters on next Set.
+	return buffer;
 }
 
 /**
@@ -544,9 +514,7 @@ StringID GetMonthName(int month)
  */
 void GetTextSize(StringID strid, int *width, int *height)
 {
-	static uint8 buffer[1024]; // Arbitrary max size.
-	DrawText(strid, buffer, lengthof(buffer));
-	_video.GetTextSize(buffer, width, height);
+	_video.GetTextSize(DrawText(strid), width, height);
 }
 
 /**
@@ -556,11 +524,11 @@ void GetTextSize(StringID strid, int *width, int *height)
  * @return The formatted string.
  * @todo Allow variable number of format parameters, e.g. "mm-yy".
  */
-const uint8 *GetDateString(const Date &d, const char *format)
+std::string GetDateString(const Date &d, const char *format)
 {
-	static uint8 textbuf[64];
-	const uint8 *month = _language.GetText(GetMonthName(d.month));
-	snprintf((char *)textbuf, lengthof(textbuf), format, d.day, month, d.year);
+	static char textbuf[64];
+	const std::string &month = _language.GetText(GetMonthName(d.month));
+	snprintf(textbuf, lengthof(textbuf), format, d.day, month.c_str(), d.year);
 	return textbuf;
 }
 
@@ -592,7 +560,7 @@ Point32 GetMaxDateSize()
  */
 Point32 GetMoneyStringSize(const Money &amount)
 {
-	uint8 textbuf[64];
+	char textbuf[64];
 	MoneyStrFmt(textbuf, lengthof(textbuf), (int64)amount / 100.0);
 	Point32 p;
 	_video.GetTextSize(textbuf, &p.x, &p.y);

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -39,7 +39,7 @@ void TextString::Clear()
 }
 
 /** Known languages. */
-const char * const _lang_names[] = {
+const std::string _lang_names[] = {
 	"da_DK", // Danish.
 	"de_DE", // German.
 	"en_GB", // English (Also the default language).
@@ -58,14 +58,14 @@ assert_compile(lengthof(_lang_names) == LANGUAGE_COUNT); ///< Ensure number of l
  * @param lang_name Name of the language.
  * @return Index of the language with the provided name, or \c -1 if not recognized.
  */
-int GetLanguageIndex(const char *lang_name)
+int GetLanguageIndex(const std::string &lang_name)
 {
 	int start = 0; // Exclusive lower bound.
 	int end = LANGUAGE_COUNT; // Exclusive upper bound.
 
 	while (start + 1 < end) {
 		int middle = (start + end) / 2;
-		int cmp = strcmp(_lang_names[middle], lang_name);
+		int cmp = _lang_names[middle].compare(lang_name);
 		if (cmp == 0) return middle; // Jack pot.
 		if (cmp < 0) {
 			start = middle;
@@ -73,37 +73,36 @@ int GetLanguageIndex(const char *lang_name)
 			end = middle;
 		}
 	}
-	if (!strcmp(_lang_names[start], lang_name)) return start;
+	if (_lang_names[start] == lang_name) return start;
 	return -1;
 }
 
 /**
  * Get the name of a given language index.
  * @param index Index of the language.
- * @return Name of the language, or \c nullptr if the index is invalid.
+ * @return Name of the language, or \c "" if the index is invalid.
  */
-const char *GetLanguageName(const int index)
+std::string GetLanguageName(const int index)
 {
-	if (index < 0 || index >= LANGUAGE_COUNT) return nullptr;
+	if (index < 0 || index >= LANGUAGE_COUNT) return std::string();
 	return _lang_names[index];
 }
 
 /**
  * Try to find a language whose name is similar to the provided name.
  * @param lang_name Name to compare to.
- * @return Most similar language name, or \c nullptr if no language has a similar name.
+ * @return Most similar language name, or \c "" if no language has a similar name.
  */
-const char *GetSimilarLanguage(const std::string& lang_name)
+std::string GetSimilarLanguage(const std::string& lang_name)
 {
-	const char *best_match = nullptr;
+	std::string best_match;
 	double score = 1.5;  // Arbitrary treshold to suppress random matches.
 	for (int i = 0; i < LANGUAGE_COUNT; ++i) {
-		const std::string name(_lang_names[i]);
-		const int common_length = std::min(name.size(), lang_name.size());
-		double s = common_length - std::max<int>(name.size(), lang_name.size());
+		const int common_length = std::min(_lang_names[i].size(), lang_name.size());
+		double s = common_length - std::max<int>(_lang_names[i].size(), lang_name.size());
 		for (int j = 0; j < common_length; ++j) {
 			const char c1 = lang_name.at(j);
-			const char c2 = name.at(j);
+			const char c2 = _lang_names[i].at(j);
 			if (c1 == c2) {
 				s++;
 			} else if (c1 >= 'a' && c1 <= 'z' && c1 + 'A' - 'a' == c2) {

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -129,13 +129,14 @@ StringParameters::StringParameters()
 
 /**
  * Ensure that this Parameters object can hold at least a certain number of parameters.
- * @param num Minimum number of parameters.
+ * @param num_params Minimum number of parameters.
+ * @note Only call this function if you actually need at least \c 1 parameter.
  */
-void StringParameters::ReserveCapacity(const int num)
+void StringParameters::ReserveCapacity(const int num_params)
 {
-	assert(num > 0);
+	assert(num_params > 0 && num_params < 20);  // Arbitrary upper bound.
 	if (!this->set_mode) this->Clear();
-	if (this->parms.size() < num) this->parms.resize(num);
+	if (this->parms.size() < num_params) this->parms.resize(num_params);
 }
 
 /**

--- a/src/language.h
+++ b/src/language.h
@@ -191,7 +191,7 @@ extern Language _language;
 extern StringParameters _str_params;
 extern const std::string _lang_names[];
 
-std::string DrawText(StringID num, StringParameters *params = &_str_params) __attribute__((warn_unused_result));  // NOCOM
+std::string DrawText(StringID num, StringParameters *params = &_str_params);
 
 std::string GetDateString(const Date &d, const char *format = "%02d-%s-%02d");
 Point32 GetMaxDateSize();

--- a/src/language.h
+++ b/src/language.h
@@ -177,9 +177,9 @@ private:
 	uint first_free; ///< 'First' string index that is not allocated yet.
 };
 
-int GetLanguageIndex(const char *lang_name);
-const char *GetLanguageName(int index);
-const char *GetSimilarLanguage(const std::string&);
+int GetLanguageIndex(const std::string &lang_name);
+std::string GetLanguageName(int index);
+std::string GetSimilarLanguage(const std::string&);
 void InitLanguage();
 void UninitLanguage();
 
@@ -188,7 +188,7 @@ void GetTextSize(StringID num, int *width, int *height);
 
 extern Language _language;
 extern StringParameters _str_params;
-extern const char * const _lang_names[];
+extern const std::string _lang_names[];
 
 void DrawText(StringID num, uint8 *buffer, uint length, StringParameters *params = &_str_params);
 

--- a/src/language.h
+++ b/src/language.h
@@ -107,7 +107,7 @@ public:
 	{
 		if (_current_language < 0 || _current_language >= LANGUAGE_COUNT) return "<out of bounds>";
 		if (this->languages[_current_language] != nullptr) return this->languages[_current_language];
-		if (this->languages[LANG_EN_GB       ] != nullptr) return this->languages[LANG_EN_GB];
+		if (this->languages[LANG_EN_GB] != nullptr) return this->languages[LANG_EN_GB];
 		return "<no-text>";
 	}
 
@@ -149,7 +149,7 @@ struct StringParameters {
 	void SetDate(int num, const Date &date);
 	void SetTemperature(int num, int value);
 	void SetText(int num, const std::string &text);
-	void ReserveCapacity(int num);
+	void ReserveCapacity(int num_params);
 
 	void Clear();
 

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -172,12 +172,12 @@ uint64 Loader::GetLongLong()
 
 /**
  * Load a text from the save into memory.
- * @return Utf-8 encoded string. Caller must delete the memory after use.
+ * @return Utf-8 encoded string.
  */
-uint8 *Loader::GetText()
+std::string Loader::GetText()
 {
 	uint32 length = this->GetLong();
-	if (length == 0) return nullptr;
+	if (length == 0) return std::string();
 
 	std::unique_ptr<uint32[]> cpoints(new uint32[length]);
 
@@ -185,14 +185,14 @@ uint8 *Loader::GetText()
 
 	size_t enc_length = 0;
 	for (uint32 i = 0; i < length; i++) enc_length += EncodeUtf8Char(cpoints[i], nullptr);
-	std::unique_ptr<uint8[]> txt(new uint8[enc_length + 1]);
-	uint8 *p = txt.get();
+	std::unique_ptr<char[]> txt(new char[enc_length + 1]);
+	char *p = txt.get();
 	for (uint32 i = 0; i < length; i++) {
 		size_t len = EncodeUtf8Char(cpoints[i], p);
 		p += len;
 	}
 	txt[enc_length] = '\0';
-	return txt.release();
+	return txt.get();
 }
 
 /**
@@ -293,13 +293,11 @@ void Saver::PutLongLong(uint64 val)
  * @param str String to save.
  * @param length Number of bytes in the string if specified, else negative.
  */
-void Saver::PutText(const uint8 *str, int length)
+void Saver::PutText(const std::string &str, int length)
 {
-	if (str == nullptr) str = (const uint8 *)"";
-
 	/* Get size of the string in code points. */
 	uint32 count = 0;
-	const uint8 *p = str;
+	const char *p = str.c_str();
 	size_t size = (length >= 0) ? static_cast<size_t>(length) : 4; // 4 is max utf-8 character length.
 	for (;;) {
 		uint32 cpoint;
@@ -312,11 +310,12 @@ void Saver::PutText(const uint8 *str, int length)
 
 	this->PutLong(count);
 	size = (length >= 0) ? static_cast<size_t>(length) : 4; // 4 is max utf-8 character length.
+	p = str.c_str();
 	while (count > 0) {
 		uint32 cpoint;
-		int len = DecodeUtf8Char(str, size, &cpoint);
+		int len = DecodeUtf8Char(p, size, &cpoint);
 		if (len == 0 || cpoint == 0) break;
-		str += len;
+		p += len;
 		if (length >= 0) size -= len;
 		this->PutLong(cpoint);
 		count--;

--- a/src/loadsave.h
+++ b/src/loadsave.h
@@ -34,7 +34,7 @@ public:
 	uint16 GetWord();
 	uint32 GetLong();
 	uint64 GetLongLong();
-	uint8 *GetText();
+	std::string GetText();
 
 	void version_mismatch(uint saved_version, uint current_version);
 
@@ -61,7 +61,7 @@ public:
 	void PutWord(uint16 val);
 	void PutLong(uint32 val);
 	void PutLongLong(uint64 val);
-	void PutText(const uint8 *str, int length = -1);
+	void PutText(const std::string &str, int length = -1);
 
 	void CheckNoOpenPattern() const;
 

--- a/src/loadsave_gui.cpp
+++ b/src/loadsave_gui.cpp
@@ -117,7 +117,7 @@ void LoadSaveGui::SetWidgetStringParameters(const WidgetNumber wid_num) const
  */
 std::string LoadSaveGui::FinalFilename() const
 {
-	std::string result(reinterpret_cast<const char*>(this->GetWidget<TextInputWidget>(LSW_TEXTFIELD)->GetText()));
+	std::string result = this->GetWidget<TextInputWidget>(LSW_TEXTFIELD)->GetText();
 	if (result.size() < 5 || result.compare(result.size() - 4, 4, ".fct")) result += ".fct";
 	return result;
 }
@@ -138,9 +138,7 @@ void LoadSaveGui::OnClick(const WidgetNumber number, const Point16 &pos)
 
 			auto selected = this->all_files.begin();
 			std::advance(selected, index);
-			uint8 *buffer = new uint8[selected->size() + 1];
-			strcpy(reinterpret_cast<char*>(buffer), selected->c_str());
-			this->GetWidget<TextInputWidget>(LSW_TEXTFIELD)->SetText(buffer);
+			this->GetWidget<TextInputWidget>(LSW_TEXTFIELD)->SetText(*selected);
 			break;
 		}
 

--- a/src/loadsave_gui.cpp
+++ b/src/loadsave_gui.cpp
@@ -185,7 +185,7 @@ void LoadSaveGui::DrawWidget(const WidgetNumber wid_num, const BaseWidget *wid) 
 			_video.FillRectangle(Rectangle32(x - ITEM_SPACING, y, w + 2 * ITEM_SPACING, ITEM_HEIGHT),
 					_palette[COL_SERIES_START + COL_RANGE_BLUE * COL_SERIES_LENGTH + 1]);
 		}
-		_video.BlitText(reinterpret_cast<const uint8*>(iterator->c_str()), _palette[TEXT_WHITE], x, y, w, ALG_LEFT);
+		_video.BlitText(*iterator, _palette[TEXT_WHITE], x, y, w, ALG_LEFT);
 	}
 }
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -52,6 +52,12 @@ MainMenuGui::MainMenuGui() : Window(WC_MAIN_MENU, ALL_WINDOWS_OF_TYPE), camera_p
 	this->nr_cameras = this->camera_positions.GetNum("camera", "nr_cameras");
 	this->time_in_camera = 0;
 	this->current_camera_id = 0;
+
+	/* Mark all expected config file entries as used. */
+	for (uint32 i = 0; i < this->nr_cameras; i++) {
+		const std::string section = std::to_string(i);
+		for (const std::string &key : {"x", "y", "z", "orientation", "duration"}) camera_positions.GetValue(section, key);
+	}
 }
 
 MainMenuGui::~MainMenuGui()
@@ -98,16 +104,16 @@ void MainMenuGui::OnDraw(MouseModeSelector *selector)
 	}
 
 	this->time_in_camera += (current_time - last_time);
-	if (this->time_in_camera > this->camera_positions.GetNum(std::to_string(this->current_camera_id).c_str(), "duration")) {
+	if (this->time_in_camera > this->camera_positions.GetNum(std::to_string(this->current_camera_id), "duration")) {
 		this->current_camera_id++;
 		this->current_camera_id %= this->nr_cameras;
 		this->time_in_camera = 0;
 		const std::string section = std::to_string(this->current_camera_id);
 		Viewport *vp = _window_manager.GetViewport();
-		vp->orientation = static_cast<ViewOrientation>(this->camera_positions.GetNum(section.c_str(), "orientation"));
-		vp->view_pos.x  =                              this->camera_positions.GetNum(section.c_str(), "x");
-		vp->view_pos.y  =                              this->camera_positions.GetNum(section.c_str(), "y");
-		vp->view_pos.z  =                              this->camera_positions.GetNum(section.c_str(), "z");
+		vp->orientation = static_cast<ViewOrientation>(this->camera_positions.GetNum(section, "orientation"));
+		vp->view_pos.x  =                              this->camera_positions.GetNum(section, "x");
+		vp->view_pos.y  =                              this->camera_positions.GetNum(section, "y");
+		vp->view_pos.z  =                              this->camera_positions.GetNum(section, "z");
 	}
 	this->last_time = current_time;
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -45,11 +45,10 @@ private:
 
 bool MainMenuGui::is_splash_screen = true;
 
-MainMenuGui::MainMenuGui() : Window(WC_MAIN_MENU, ALL_WINDOWS_OF_TYPE)
+MainMenuGui::MainMenuGui() : Window(WC_MAIN_MENU, ALL_WINDOWS_OF_TYPE), camera_positions(FindDataFile("data/mainmenu/camera"))
 {
 	this->SetSize(_video.GetXSize(),_video.GetYSize());
 	this->animstart = this->last_time = SDL_GetTicks();
-	this->camera_positions.Load(FindDataFile("data/mainmenu/camera").c_str());
 	this->nr_cameras = this->camera_positions.GetNum("camera", "nr_cameras");
 	this->time_in_camera = 0;
 	this->current_camera_id = 0;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -93,7 +93,7 @@ void Message::InitMessageDataTypes()
 			return;
 
 		default:
-			printf("ERROR: Invalid message string %d ('%s')\n", this->message, _language.GetText(this->message));
+			printf("ERROR: Invalid message string %d ('%s')\n", this->message, _language.GetText(this->message).c_str());
 			NOT_REACHED();
 	}
 }
@@ -109,13 +109,13 @@ void Message::SetStringParameters() const
 			_str_params.SetNumber(1, this->data1);
 			break;
 		case MDT_GUEST:
-			_str_params.SetUint8(1, _guests.Get(this->data1)->GetName());
+			_str_params.SetText(1, _guests.Get(this->data1)->GetName());
 			break;
 		case MDT_RIDE_TYPE:
 			_str_params.SetStrID(1, _rides_manager.GetRideType(this->data1)->GetTypeName());
 			break;
 		case MDT_RIDE_INSTANCE:
-			_str_params.SetUint8(1, _rides_manager.GetRideInstance(this->data1)->name.get());
+			_str_params.SetText(1, _rides_manager.GetRideInstance(this->data1)->name);
 			_str_params.SetNumber(2, this->data2);
 			break;
 		default:

--- a/src/people.cpp
+++ b/src/people.cpp
@@ -496,6 +496,18 @@ void Staff::RequestMechanic(RideInstance *ride)
 }
 
 /**
+ * Generate the name for a newly hired staff member.
+ * @oaram m Staff member to name.
+ * @param text Base text for the name.
+ */
+static void NameNewStaff(StaffMember *m, StringID text)
+{
+	static char buffer[1024];
+	snprintf(buffer, lengthof(buffer), _language.GetText(text).c_str(), STAFF_BASE_ID - m->id);
+	m->SetName(buffer);
+}
+
+/**
  * Hire a new mechanic.
  * @return The new mechanic.
  */
@@ -505,11 +517,7 @@ Mechanic *Staff::HireMechanic()
 	m->id = this->GenerateID();
 	m->Activate(Point16(9, 2), PERSON_MECHANIC);  // \todo Allow the player to decide where to put the new mechanic.
 	this->mechanics.push_back(std::unique_ptr<Mechanic>(m));
-
-	char buffer[1024];
-	snprintf(buffer, lengthof(buffer), reinterpret_cast<const char*>(_language.GetText(GUI_STAFF_NAME_MECHANIC)), STAFF_BASE_ID - m->id);
-	m->SetName(reinterpret_cast<uint8*>(buffer));
-
+	NameNewStaff(m, GUI_STAFF_NAME_MECHANIC);
 	return m;
 }
 
@@ -523,11 +531,7 @@ Handyman *Staff::HireHandyman()
 	m->id = this->GenerateID();
 	m->Activate(Point16(9, 2), PERSON_HANDYMAN);  // \todo Allow the player to decide where to put the new handyman.
 	this->handymen.push_back(std::unique_ptr<Handyman>(m));
-
-	char buffer[1024];
-	snprintf(buffer, lengthof(buffer), reinterpret_cast<const char*>(_language.GetText(GUI_STAFF_NAME_HANDYMAN)), STAFF_BASE_ID - m->id);
-	m->SetName(reinterpret_cast<uint8*>(buffer));
-
+	NameNewStaff(m, GUI_STAFF_NAME_HANDYMAN);
 	return m;
 }
 
@@ -541,11 +545,7 @@ Guard *Staff::HireGuard()
 	m->id = this->GenerateID();
 	m->Activate(Point16(9, 2), PERSON_GUARD);  // \todo Allow the player to decide where to put the new guard.
 	this->guards.push_back(std::unique_ptr<Guard>(m));
-
-	char buffer[1024];
-	snprintf(buffer, lengthof(buffer), reinterpret_cast<const char*>(_language.GetText(GUI_STAFF_NAME_GUARD)), STAFF_BASE_ID - m->id);
-	m->SetName(reinterpret_cast<uint8*>(buffer));
-
+	NameNewStaff(m, GUI_STAFF_NAME_GUARD);
 	return m;
 }
 
@@ -559,11 +559,7 @@ Entertainer *Staff::HireEntertainer()
 	m->id = this->GenerateID();
 	m->Activate(Point16(9, 2), PERSON_ENTERTAINER);  // \todo Allow the player to decide where to put the new entertainer.
 	this->entertainers.push_back(std::unique_ptr<Entertainer>(m));
-
-	char buffer[1024];
-	snprintf(buffer, lengthof(buffer), reinterpret_cast<const char*>(_language.GetText(GUI_STAFF_NAME_ENTERTAINER)), STAFF_BASE_ID - m->id);
-	m->SetName(reinterpret_cast<uint8*>(buffer));
-
+	NameNewStaff(m, GUI_STAFF_NAME_ENTERTAINER);
 	return m;
 }
 

--- a/src/person.h
+++ b/src/person.h
@@ -132,9 +132,9 @@ public:
 	bool IsQueuingGuest() const;
 	bool IsQueuingGuestNearby(const XYZPoint16& vox_pos, const XYZPoint16& pix_pos, bool only_in_front);
 
-	void SetName(const uint8 *name);
-	const uint8 *GetName() const;
-	const uint8 *GetStatus() const;
+	void SetName(const std::string &name);
+	std::string GetName() const;
+	std::string GetStatus() const;
 
 	uint16 id;       ///< Unique id of the person.
 	PersonType type; ///< Type of person.
@@ -150,7 +150,7 @@ public:
 
 protected:
 	Random rnd; ///< Random number generator for deciding how the person reacts.
-	std::unique_ptr<uint8[]> name; ///< Name of the person. \c nullptr means it has a default name (like "Guest XYZ").
+	std::string name; ///< Name of the person. \c "" means it has a default name (like "Guest XYZ").
 	StringID status;  ///< What the person is doing right now, for display in the GUI.
 
 	TileEdge GetCurrentEdge() const;

--- a/src/person_gui.cpp
+++ b/src/person_gui.cpp
@@ -94,11 +94,11 @@ void GuestInfoWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 {
 	switch (wid_num) {
 		case GIW_TITLEBAR:
-			_str_params.SetUint8(1, (uint8 *)this->guest->GetName());
+			_str_params.SetText(1, this->guest->GetName());
 			break;
 
 		case GIW_STATUS:
-			_str_params.SetUint8(1, this->guest->GetStatus());
+			_str_params.SetText(1, this->guest->GetStatus());
 			break;
 
 		case GIW_MONEY:
@@ -191,7 +191,7 @@ void StaffInfoWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 {
 	switch (wid_num) {
 		case SIW_TITLEBAR:
-			_str_params.SetUint8(1, this->person->GetName());
+			_str_params.SetText(1, this->person->GetName());
 			break;
 
 		case SIW_SALARY:
@@ -199,7 +199,7 @@ void StaffInfoWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 			break;
 
 		case SIW_STATUS: {
-			_str_params.SetUint8(1, this->person->GetStatus());
+			_str_params.SetText(1, this->person->GetStatus());
 			break;
 		}
 

--- a/src/ride_build.cpp
+++ b/src/ride_build.cpp
@@ -139,7 +139,7 @@ void RideBuildWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 				const RideType *ride_type = this->instance->GetRideType();
 				_str_params.SetStrID(1, ride_type->GetString(ride_type->GetTypeName()));
 			} else {
-				_str_params.SetUint8(1, (uint8 *)"Unknown");
+				_str_params.SetText(1, "Unknown");
 			}
 			break;
 

--- a/src/ride_type.h
+++ b/src/ride_type.h
@@ -17,8 +17,7 @@
 #include "money.h"
 #include "random.h"
 
-static const int MAX_RIDE_INSTANCE_NAME_LENGTH = 64; ///< Maximum number of characters in ride instance name.
-static const uint16 INVALID_RIDE_INSTANCE      = 0xFFFF; ///< Value representing 'no ride instance found'.
+static const uint16 INVALID_RIDE_INSTANCE = 0xFFFF; ///< Value representing 'no ride instance found'.
 
 static const int MAX_RIDE_RECOLOURS = 3;  ///< Maximum number of entries in a RideInstance's recolour map.
 
@@ -206,7 +205,7 @@ public:
 
 	uint16 GetIndex() const;
 
-	std::unique_ptr<uint8[]> name;  ///< Name of the ride, if it is instantiated.
+	std::string name;               ///< Name of the ride, if it is instantiated.
 	uint8 state;                    ///< State of the instance. @see RideInstanceState
 	uint8 flags;                    ///< Flags of the instance. @see RideInstanceFlags
 	Recolouring recolours;          ///< Recolour map of the instance.
@@ -246,7 +245,7 @@ class RidesManager {
 public:
 	RideInstance *GetRideInstance(uint16 num);
 	const RideInstance *GetRideInstance(uint16 num) const;
-	RideInstance *FindRideByName(const uint8 *name);
+	RideInstance *FindRideByName(const std::string &name);
 
 	void AddRideType(std::unique_ptr<RideType> type);
 	void AddRideEntranceExitType(std::unique_ptr<RideEntranceExitType> &type);

--- a/src/setting_gui.cpp
+++ b/src/setting_gui.cpp
@@ -85,7 +85,7 @@ void SettingWindow::OnClick(WidgetNumber number, const Point16 &pos)
 		case SW_LANGUAGE: {
 			DropdownList itemlist;
 			for (int i = 0; i < LANGUAGE_COUNT; i++) {
-				_str_params.SetUint8(1, _language.GetLanguageName(i));
+				_str_params.SetText(1, _language.GetLanguageName(i));
 				itemlist.push_back(DropdownItem(STR_ARG1));
 			}
 			this->ShowDropdownMenu(number, itemlist, _current_language);

--- a/src/shop_gui.cpp
+++ b/src/shop_gui.cpp
@@ -48,7 +48,7 @@ void ShopRemoveWindow::OnClick(WidgetNumber number, const Point16 &pos)
 
 void ShopRemoveWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 {
-	if (wid_num == ERW_MESSAGE) _str_params.SetUint8(1, (uint8 *)this->si->name.get());
+	if (wid_num == ERW_MESSAGE) _str_params.SetText(1, this->si->name);
 }
 
 /**
@@ -203,7 +203,7 @@ void ShopManagerWindow::SetWidgetStringParameters(WidgetNumber wid_num) const
 {
 	switch (wid_num) {
 		case SMW_TITLEBAR:
-			_str_params.SetUint8(1, this->shop->name.get());
+			_str_params.SetText(1, this->shop->name);
 			break;
 
 		case SMW_ITEM1_COST:

--- a/src/sprite_store.cpp
+++ b/src/sprite_store.cpp
@@ -145,7 +145,7 @@ bool TextData::Load(RcdFileReader *rcd_file)
 			if (!ReadUtf8Text(rcd_file, lang_length, lang_buffer, lengthof(lang_buffer), &used)) return false;
 			length -= lang_length;
 
-			int lang_idx = GetLanguageIndex((char *)lang_buffer);
+			int lang_idx = GetLanguageIndex(lang_buffer);
 			/* Read translation text. */
 			if (lang_idx >= 0) {
 				strings[used_strings].languages[lang_idx] = buffer + used_size;

--- a/src/sprite_store.h
+++ b/src/sprite_store.h
@@ -45,7 +45,7 @@ public:
 
 	uint string_count;   ///< Number of strings in #strings.
 	std::unique_ptr<TextString[]> strings; ///< Strings of the text.
-	std::unique_ptr<uint8[]> text_data;    ///< Text data (UTF-8) itself.
+	std::unique_ptr<char[]> text_data;     ///< Text data (UTF-8) itself.
 };
 
 typedef std::map<uint32, TextData *> TextMap; ///< Map of loaded text blocks.

--- a/src/staff_gui.cpp
+++ b/src/staff_gui.cpp
@@ -186,9 +186,9 @@ void StaffManagementGui::DrawWidget(const WidgetNumber wid_num, const BaseWidget
 		y += GetTextHeight();
 		StaffMember *person = _staff.Get(this->selected, i);
 
-		_str_params.SetUint8(1, person->GetName());
+		_str_params.SetText(1, person->GetName());
 		DrawString(STR_ARG1, TEXT_BLACK, column1x + 2, y, w, ALG_LEFT);
-		_str_params.SetUint8(1, person->GetStatus());
+		_str_params.SetText(1, person->GetStatus());
 		DrawString(STR_ARG1, TEXT_BLACK, column2x + 2, y, w, ALG_LEFT);
 
 		_video.BlitImage({x + w - _gui_sprites.close_sprite->width - 2, y}, _gui_sprites.close_sprite, rc, GS_NORMAL);

--- a/src/string_func.cpp
+++ b/src/string_func.cpp
@@ -95,7 +95,7 @@ size_t StrBytesLength(const uint8 *str)
  * @param[out] codepoint If decoding was successful, the value of the decoded character.
  * @return Number of bytes read to decode the character, or \c 0 if reading failed.
  */
-int DecodeUtf8Char(const uint8 *data, size_t length, uint32 *codepoint)
+int DecodeUtf8Char(const char *data, size_t length, uint32 *codepoint)
 {
 	if (length < 1) return 0;
 	uint32 value = *data;
@@ -124,7 +124,7 @@ int DecodeUtf8Char(const uint8 *data, size_t length, uint32 *codepoint)
 
 	if (length < static_cast<size_t>(size)) return 0;
 	for (int n = 1; n < size; n++) {
-		uint8 val = *data;
+		char val = *data;
 		data++;
 		if ((val & 0xC0) != 0x80) return 0;
 		value = (value << 6) | (val & 0x3F);
@@ -141,7 +141,7 @@ int DecodeUtf8Char(const uint8 *data, size_t length, uint32 *codepoint)
  * @return Length of the encoded character in bytes.
  * @note It is recommended to use this function for measuring required output size (by making \a dest a \c nullptr), before writing the encoded string.
  */
-int EncodeUtf8Char(uint32 codepoint, uint8 *dest)
+int EncodeUtf8Char(uint32 codepoint, char *dest)
 {
 	if (codepoint < 0x7F + 1) {
 		/* 7 bits, U+0000 .. U+007F, 1 byte: 0xxx.xxxx */

--- a/src/string_func.cpp
+++ b/src/string_func.cpp
@@ -183,7 +183,7 @@ int EncodeUtf8Char(uint32 codepoint, uint8 *dest)
  * @param pos Index in the string to start searching from.
  * @return The previous character's index.
  */
-size_t GetPrevChar(const uint8 *data, size_t pos)
+size_t GetPrevChar(const std::string &data, size_t pos)
 {
 	if (pos == 0) return 0;
 	do {
@@ -198,9 +198,9 @@ size_t GetPrevChar(const uint8 *data, size_t pos)
  * @param pos Index in the string to start searching from.
  * @return The next character's index.
  */
-size_t GetNextChar(const uint8 *data, size_t pos)
+size_t GetNextChar(const std::string &data, size_t pos)
 {
-	const size_t length = StrBytesLength(data);
+	const size_t length = data.size();
 	if (pos >= length) return length;
 	do {
 		pos++;

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -17,8 +17,8 @@ uint8 *StrECpy(uint8 *dest, uint8 *end, const uint8 *src);
 
 size_t StrBytesLength(const uint8 *txt);
 
-int DecodeUtf8Char(const uint8 *data, size_t length, uint32 *codepoint);
-int EncodeUtf8Char(uint32 codepoint, uint8 *dest = nullptr);
+int DecodeUtf8Char(const char *data, size_t length, uint32 *codepoint);
+int EncodeUtf8Char(uint32 codepoint, char *dest = nullptr);
 size_t GetPrevChar(const std::string &data, size_t pos);
 size_t GetNextChar(const std::string &data, size_t pos);
 

--- a/src/string_func.h
+++ b/src/string_func.h
@@ -19,8 +19,8 @@ size_t StrBytesLength(const uint8 *txt);
 
 int DecodeUtf8Char(const uint8 *data, size_t length, uint32 *codepoint);
 int EncodeUtf8Char(uint32 codepoint, uint8 *dest = nullptr);
-size_t GetPrevChar(const uint8 *data, size_t pos);
-size_t GetNextChar(const uint8 *data, size_t pos);
+size_t GetPrevChar(const std::string &data, size_t pos);
+size_t GetNextChar(const std::string &data, size_t pos);
 
 bool StrEqual(const uint8 *s1, const uint8 *s2);
 bool StrEndsWith(const char *str, const char *end, bool case_sensitive);

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -725,9 +725,9 @@ void VideoSystem::BlitImages(const Point32 &pt, const ImageData *spr, uint16 num
  * @param width [out] Resulting width.
  * @param height [out] Resulting height.
  */
-void VideoSystem::GetTextSize(const uint8 *text, int *width, int *height)
+void VideoSystem::GetTextSize(const std::string &text, int *width, int *height)
 {
-	if (TTF_SizeUTF8(this->font, (const char *)text, width, height) != 0) {
+	if (TTF_SizeUTF8(this->font, text.c_str(), width, height) != 0) {
 		*width = 0;
 		*height = 0;
 	}
@@ -747,9 +747,9 @@ void VideoSystem::GetNumberRangeSize(int64 smallest, int64 biggest, int *width, 
 		this->digit_size.x = 0;
 		this->digit_size.y = 0;
 
-		uint8 buffer[2];
+		char buffer[2];
 		buffer[1] = '\0';
-		for (uint8 i = '0'; i <= '9'; i++) {
+		for (char i = '0'; i <= '9'; i++) {
 			buffer[0] = i;
 			int w, h;
 			this->GetTextSize(buffer, &w, &h);
@@ -780,10 +780,10 @@ void VideoSystem::GetNumberRangeSize(int64 smallest, int64 biggest, int *width, 
  * @param width Available width of the text (in pixels).
  * @param align Horizontal alignment of the string.
  */
-void VideoSystem::BlitText(const uint8 *text, uint32 colour, int xpos, int ypos, int width, Alignment align)
+void VideoSystem::BlitText(const std::string &text, uint32 colour, int xpos, int ypos, int width, Alignment align)
 {
 	SDL_Color col = {0, 0, 0}; // Font colour does not matter as only the bitmap is used.
-	SDL_Surface *surf = TTF_RenderUTF8_Solid(this->font, (const char *)text, col);
+	SDL_Surface *surf = TTF_RenderUTF8_Solid(this->font, text.c_str(), col);
 	if (surf == nullptr) {
 		fprintf(stderr, "Rendering text failed (%s)\n", TTF_GetError());
 		return;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -136,7 +136,7 @@ VideoSystem::~VideoSystem()
  * @param font_size Size of the font.
  * @return Error message if initialization failed, else an empty text.
  */
-std::string VideoSystem::Initialize(const char *font_name, int font_size)
+std::string VideoSystem::Initialize(const std::string &font_name, int font_size)
 {
 	if (this->initialized) return "";
 
@@ -195,7 +195,7 @@ std::string VideoSystem::Initialize(const char *font_name, int font_size)
 		return err;
 	}
 
-	this->font = TTF_OpenFont(font_name, font_size);
+	this->font = TTF_OpenFont(font_name.c_str(), font_size);
 	if (this->font == nullptr) {
 		std::string err = "TTF Opening font \"";
 		err += font_name;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -333,7 +333,7 @@ static void UpdateMousePosition(int16 x, int16 y)
  * @param symbol Entered symbol, if \a key_code is #WMKC_SYMBOL. Utf-8 encoded.
  * @return Game-ending event has happened.
  */
-static bool HandleKeyInput(WmKeyCode key_code, const uint8 *symbol)
+static bool HandleKeyInput(WmKeyCode key_code, const std::string &symbol = std::string())
 {
 	return _window_manager.KeyEvent(key_code, symbol);
 }
@@ -349,23 +349,23 @@ bool VideoSystem::HandleEvent()
 
 	switch (event.type) {
 		case SDL_TEXTINPUT:
-			return HandleKeyInput(WMKC_SYMBOL, (const uint8 *)event.text.text);
+			return HandleKeyInput(WMKC_SYMBOL, event.text.text);
 
 		case SDL_KEYDOWN:
 			switch (event.key.keysym.sym) {
-				case SDLK_UP:        return HandleKeyInput(WMKC_CURSOR_UP, nullptr);
-				case SDLK_LEFT:      return HandleKeyInput(WMKC_CURSOR_LEFT, nullptr);
-				case SDLK_RIGHT:     return HandleKeyInput(WMKC_CURSOR_RIGHT, nullptr);
-				case SDLK_DOWN:      return HandleKeyInput(WMKC_CURSOR_DOWN, nullptr);
-				case SDLK_HOME:      return HandleKeyInput(WMKC_CURSOR_HOME, nullptr);
-				case SDLK_END:       return HandleKeyInput(WMKC_CURSOR_END, nullptr);
-				case SDLK_ESCAPE:    return HandleKeyInput(WMKC_CANCEL, nullptr);
-				case SDLK_DELETE:    return HandleKeyInput(WMKC_DELETE, nullptr);
-				case SDLK_BACKSPACE: return HandleKeyInput(WMKC_BACKSPACE, nullptr);
+				case SDLK_UP:        return HandleKeyInput(WMKC_CURSOR_UP);
+				case SDLK_LEFT:      return HandleKeyInput(WMKC_CURSOR_LEFT);
+				case SDLK_RIGHT:     return HandleKeyInput(WMKC_CURSOR_RIGHT);
+				case SDLK_DOWN:      return HandleKeyInput(WMKC_CURSOR_DOWN);
+				case SDLK_HOME:      return HandleKeyInput(WMKC_CURSOR_HOME);
+				case SDLK_END:       return HandleKeyInput(WMKC_CURSOR_END);
+				case SDLK_ESCAPE:    return HandleKeyInput(WMKC_CANCEL);
+				case SDLK_DELETE:    return HandleKeyInput(WMKC_DELETE);
+				case SDLK_BACKSPACE: return HandleKeyInput(WMKC_BACKSPACE);
 
 				case SDLK_RETURN:
 				case SDLK_RETURN2:
-				case SDLK_KP_ENTER:  return HandleKeyInput(WMKC_CONFIRM, nullptr);
+				case SDLK_KP_ENTER:  return HandleKeyInput(WMKC_CONFIRM);
 
 				default:             return false;
 			}

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -782,6 +782,7 @@ void VideoSystem::GetNumberRangeSize(int64 smallest, int64 biggest, int *width, 
  */
 void VideoSystem::BlitText(const std::string &text, uint32 colour, int xpos, int ypos, int width, Alignment align)
 {
+	if (text.empty()) return;
 	SDL_Color col = {0, 0, 0}; // Font colour does not matter as only the bitmap is used.
 	SDL_Surface *surf = TTF_RenderUTF8_Solid(this->font, text.c_str(), col);
 	if (surf == nullptr) {

--- a/src/video.h
+++ b/src/video.h
@@ -149,18 +149,12 @@ public:
 		return this->font_height;
 	}
 
-	void GetTextSize(const uint8 *text, int *width, int *height);
+	void GetTextSize(const std::string &text, int *width, int *height);
 	void GetNumberRangeSize(int64 smallest, int64 biggest, int *width, int *height);
-	void BlitText(const uint8 *text, uint32 colour, int xpos, int ypos, int width = 0x7FFF, Alignment align = ALG_LEFT);
+	void BlitText(const std::string &text, uint32 colour, int xpos, int ypos, int width = 0x7FFF, Alignment align = ALG_LEFT);
 	void DrawLine(const Point16 &start, const Point16 &end, uint32 colour);
 	void DrawRectangle(const Rectangle32 &rect, uint32 colour);
 	void FillRectangle(const Rectangle32 &rect, uint32 colour);
-
-	// NOCOM get rid
-	inline void GetTextSize(const std::string &text, int *width, int *height)
-	{
-		return GetTextSize(reinterpret_cast<const uint8*>(text.c_str()), width, height);
-	}
 
 	bool missing_sprites; ///< Indicates that some sprites cannot be drawn.
 	std::set<Point32> resolutions; ///< Set (for automatic sorting) of available resolutions.

--- a/src/video.h
+++ b/src/video.h
@@ -156,6 +156,12 @@ public:
 	void DrawRectangle(const Rectangle32 &rect, uint32 colour);
 	void FillRectangle(const Rectangle32 &rect, uint32 colour);
 
+	// NOCOM get rid
+	inline void GetTextSize(const std::string &text, int *width, int *height)
+	{
+		return GetTextSize(reinterpret_cast<const uint8*>(text.c_str()), width, height);
+	}
+
 	bool missing_sprites; ///< Indicates that some sprites cannot be drawn.
 	std::set<Point32> resolutions; ///< Set (for automatic sorting) of available resolutions.
 

--- a/src/video.h
+++ b/src/video.h
@@ -57,7 +57,7 @@ public:
 	VideoSystem();
 	~VideoSystem();
 
-	std::string Initialize(const char *font_name, int font_size);
+	std::string Initialize(const std::string &font_name, int font_size);
 	bool SetResolution(const Point32 &res);
 	void GetResolutions();
 	void MainLoop();

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -1153,7 +1153,7 @@ void Viewport::MoveViewport(int dx, int dy)
 	}
 }
 
-bool Viewport::OnKeyEvent(WmKeyCode key_code, const uint8 *symbol)
+bool Viewport::OnKeyEvent(WmKeyCode key_code, const std::string &symbol)
 {
 	if (key_code == WMKC_SYMBOL) {
 		if (symbol[0] == 'q') {

--- a/src/viewport.h
+++ b/src/viewport.h
@@ -124,7 +124,7 @@ public:
 	bool underground_mode;       ///< Whether underground mode is displayed in this viewport.
 
 protected:
-	bool OnKeyEvent(WmKeyCode key_code, const uint8 *symbol) override;
+	bool OnKeyEvent(WmKeyCode key_code, const std::string &symbol) override;
 	void OnMouseMoveEvent(const Point16 &pos) override;
 	WmMouseEvent OnMouseButtonEvent(uint8 state) override;
 	void OnMouseWheelEvent(int direction) override;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -718,7 +718,7 @@ void TextInputWidget::Draw(const GuiWindow *w)
 	r.width -= 2 * TEXT_INPUT_MARGIN;
 	r.height -= 2 * TEXT_INPUT_MARGIN;
 	if (!this->buffer.empty()) {
-		_video.BlitText(reinterpret_cast<const uint8*>(this->buffer.c_str()) /* NOCOM */, _palette[COL_SERIES_START + this->colour * COL_SERIES_LENGTH - 2],
+		_video.BlitText(this->buffer, _palette[COL_SERIES_START + this->colour * COL_SERIES_LENGTH - 2],
 				r.base.x, r.base.y, r.width, ALG_LEFT);
 	}
 	_video.DrawLine(Point16(r.base.x + cursor_offset, r.base.y), Point16(r.base.x + cursor_offset, r.base.y + r.height),

--- a/src/widget.h
+++ b/src/widget.h
@@ -84,7 +84,7 @@ public:
 	virtual void Draw(const GuiWindow *w);
 	virtual BaseWidget *GetWidgetByPosition(const Point16 &pt);
 	virtual void AutoRaiseButtons(const Point32 &base);
-	virtual bool OnKeyEvent(WmKeyCode key_code, const uint8 *symbol);
+	virtual bool OnKeyEvent(WmKeyCode key_code, const std::string &symbol);
 
 	void MarkDirty(const Point32 &base) const;
 
@@ -222,17 +222,16 @@ class TextInputWidget : public LeafWidget {
 public:
 	TextInputWidget(WidgetType wtype);
 
-	const uint8 *GetText() const;
-	void SetText(uint8 *text);
+	const std::string &GetText() const;
+	void SetText(const std::string &text);
 	void SetCursorPos(size_t pos);
 
-	bool OnKeyEvent(WmKeyCode key_code, const uint8 *symbol) override;
+	bool OnKeyEvent(WmKeyCode key_code, const std::string &symbol) override;
 	void SetupMinimalSize(GuiWindow *w, BaseWidget **wid_array) override;
 	void Draw(const GuiWindow *w) override;
 
 private:
-	std::unique_ptr<uint8[]> buffer;  ///< Currently held text.
-	size_t text_length;               ///< Number of characters in the text.
+	std::string buffer;               ///< Currently held text.
 	size_t cursor_pos;                ///< Position of the cursor in the text.
 	int value_width;                  ///< Width of the image or the string.
 	int value_height;                 ///< Height of the image or the string.
@@ -301,7 +300,7 @@ public:
 	void Draw(const GuiWindow *w) override;
 	BaseWidget *GetWidgetByPosition(const Point16 &pt) override;
 	void AutoRaiseButtons(const Point32 &base) override;
-	bool OnKeyEvent(WmKeyCode key_code, const uint8 *symbol) override;
+	bool OnKeyEvent(WmKeyCode key_code, const std::string &symbol) override;
 
 	std::unique_ptr<BaseWidget> child; ///< Child widget displayed on top of the background widget.
 };
@@ -342,7 +341,7 @@ public:
 	BaseWidget *GetWidgetByPosition(const Point16 &pt) override;
 	void AutoRaiseButtons(const Point32 &base) override;
 	BaseWidget *FindTooltipWidget(const Point16 &pt) override;
-	bool OnKeyEvent(WmKeyCode key_code, const uint8 *symbol) override;
+	bool OnKeyEvent(WmKeyCode key_code, const std::string &symbol) override;
 
 	void AddChild(uint8 col, uint8 row, BaseWidget *sub);
 	void ClaimMemory();

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -278,7 +278,7 @@ void Window::OnMouseLeaveEvent()
  * @param symbol Entered symbol, if \a key_code is #WMKC_SYMBOL. Utf-8 encoded.
  * @return Key event has been processed.
  */
-bool Window::OnKeyEvent(WmKeyCode key_code, const uint8 *symbol)
+bool Window::OnKeyEvent(WmKeyCode key_code, const std::string &symbol)
 {
 	return false;
 }
@@ -475,7 +475,7 @@ void GuiWindow::OnDraw(MouseModeSelector *selector)
 	if ((this->flags & WF_HIGHLIGHT) != 0) _video.DrawRectangle(this->rect, MakeRGBA(255, 255, 255, OPAQUE));
 }
 
-bool GuiWindow::OnKeyEvent(WmKeyCode key_code, const uint8 *symbol)
+bool GuiWindow::OnKeyEvent(WmKeyCode key_code, const std::string &symbol)
 {
 	return this->tree->OnKeyEvent(key_code, symbol) || Window::OnKeyEvent(key_code, symbol);
 }
@@ -1100,7 +1100,7 @@ void WindowManager::MouseWheelEvent(int direction)
  * @param symbol Entered symbol, if \a key_code is #WMKC_SYMBOL. Utf-8 encoded.
  * @return Key event has been processed.
  */
-bool WindowManager::KeyEvent(WmKeyCode key_code, const uint8 *symbol)
+bool WindowManager::KeyEvent(WmKeyCode key_code, const std::string &symbol)
 {
 	for (Window *w = this->top; w != nullptr; w = w->lower) {
 		if (w->OnKeyEvent(key_code, symbol)) return true;

--- a/src/window.h
+++ b/src/window.h
@@ -70,7 +70,7 @@ public:
 	virtual void OnMouseWheelEvent(int direction);
 	virtual void OnMouseEnterEvent();
 	virtual void OnMouseLeaveEvent();
-	virtual bool OnKeyEvent(WmKeyCode key_code, const uint8 *symbol);
+	virtual bool OnKeyEvent(WmKeyCode key_code, const std::string &symbol);
 
 	virtual void TimeoutCallback();
 	virtual void SetHighlight(bool value);
@@ -100,7 +100,7 @@ public:
 	virtual void OnMouseMoveEvent(const Point16 &pos) override;
 	virtual WmMouseEvent OnMouseButtonEvent(uint8 state) override;
 	virtual void OnMouseLeaveEvent() override;
-	virtual bool OnKeyEvent(WmKeyCode key_code, const uint8 *symbol) override;
+	virtual bool OnKeyEvent(WmKeyCode key_code, const std::string &symbol) override;
 	virtual void SelectorMouseMoveEvent(Viewport *vp, const Point16 &pos);
 	virtual void SelectorMouseButtonEvent(uint8 state);
 	virtual void SelectorMouseWheelEvent(int direction);
@@ -256,7 +256,7 @@ public:
 	void MouseMoveEvent(const Point16 &pos);
 	void MouseButtonEvent(MouseButtons button, bool pressed);
 	void MouseWheelEvent(int direction);
-	bool KeyEvent(WmKeyCode key_code, const uint8 *symbol);
+	bool KeyEvent(WmKeyCode key_code, const std::string &symbol);
 	void Tick();
 
 	/**

--- a/src/window.h
+++ b/src/window.h
@@ -27,9 +27,9 @@ class MouseModeSelector;
 /** An item in a dropdown list. */
 class DropdownItem {
 public:
-	DropdownItem(StringID strid);
+	explicit DropdownItem(StringID strid);
 
-	uint8 str[128]; ///< Item, as a string (arbitary length).
+	const std::string str;  ///< Item, as a string.
 };
 
 /** A dropdown list is a collection of #DropdownItem items. */


### PR DESCRIPTION
Re #212
This refactors most (but not all) uses of `uint8*` to `std::string` or `char*`. Actually some (most) parts of our string magic that now use `char*` could do with a full rewrite from scratch using `std::string`, but that's out of scope for this branch. 