### PR TITLE
Fix queuing guests deadlocking each other

### DIFF
--- a/src/person.cpp
+++ b/src/person.cpp
@@ -951,7 +951,7 @@ RideVisitDesire Person::ComputeExitDesire(TileEdge current_edge, XYZPoint16 cur_
 			case EDGE_SE: tile_edge_pix_pos.y = 255; break;
 			default: NOT_REACHED();
 		}
-		if (this->GetQueuingGuestNearby(original_cur_pos, tile_edge_pix_pos, false) != nullptr) {
+		if (!this->IsQueuingGuest() && this->GetQueuingGuestNearby(original_cur_pos, tile_edge_pix_pos, false) != nullptr) {
 			ri->NotifyLongQueue();
 			return RVD_NO_VISIT;
 		}

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -409,6 +409,7 @@ void Person::Activate(const Point16 &start, PersonType person_type)
 	this->vox_pos.y = start.y;
 	this->vox_pos.z = _world.GetBaseGroundHeight(start.x, start.y);
 	this->AddSelf(_world.GetCreateVoxel(this->vox_pos, false));
+	this->queuing_blocked_on = nullptr;
 
 	if (start.x == 0) {
 		this->pix_pos.x = 0;
@@ -832,6 +833,8 @@ void Person::Load(Loader &ldr)
 	if (version < 1 || version > CURRENT_VERSION_Person) ldr.version_mismatch(version, CURRENT_VERSION_Person);
 	this->VoxelObject::Load(ldr);
 
+	this->queuing_blocked_on = nullptr;  // Will be recalculated later in OnAnimate().
+
 	this->type = (PersonType)ldr.GetByte();
 	this->offset = ldr.GetWord();
 	this->name = ldr.GetText();
@@ -948,7 +951,7 @@ RideVisitDesire Person::ComputeExitDesire(TileEdge current_edge, XYZPoint16 cur_
 			case EDGE_SE: tile_edge_pix_pos.y = 255; break;
 			default: NOT_REACHED();
 		}
-		if (this->IsQueuingGuestNearby(original_cur_pos, tile_edge_pix_pos, false)) {
+		if (this->GetQueuingGuestNearby(original_cur_pos, tile_edge_pix_pos, false) != nullptr) {
 			ri->NotifyLongQueue();
 			return RVD_NO_VISIT;
 		}
@@ -1412,9 +1415,9 @@ bool Person::IsQueuingGuest() const
  * @param vox_pos Coordinates of the voxel in the world.
  * @param pix_pos Pixel position inside the voxel.
  * @param only_in_front Whether to consider only guests standing in front of this one.
- * @return Another queuing guest is close by.
+ * @return A queuing guest close by, or \c nullptr if there isn't one.
  */
-bool Person::IsQueuingGuestNearby(const XYZPoint16& vox_pos, const XYZPoint16& pix_pos, const bool only_in_front)
+const Person *Person::GetQueuingGuestNearby(const XYZPoint16& vox_pos, const XYZPoint16& pix_pos, const bool only_in_front)
 {
 	/*
 	 * To ensure that guests on a neighbouring tile are also considered, we also need to check
@@ -1441,17 +1444,17 @@ bool Person::IsQueuingGuestNearby(const XYZPoint16& vox_pos, const XYZPoint16& p
 
 				const XYZPoint32 coords = g->MergeCoordinates();
 				if (hypot(coords.x - merged_pos.x, coords.y - merged_pos.y) < QUEUE_DISTANCE) {
-					if (!only_in_front) return true;
+					if (!only_in_front) return g;
 					const AnimationFrame &frame = this->frames[this->frame_index];
-					if (frame.dx > 0 && coords.x > merged_pos.x) return true;
-					if (frame.dx < 0 && coords.x < merged_pos.x) return true;
-					if (frame.dy > 0 && coords.y > merged_pos.y) return true;
-					if (frame.dy < 0 && coords.y < merged_pos.y) return true;
+					if (frame.dx > 0 && coords.x > merged_pos.x) return g;
+					if (frame.dx < 0 && coords.x < merged_pos.x) return g;
+					if (frame.dy > 0 && coords.y > merged_pos.y) return g;
+					if (frame.dy < 0 && coords.y < merged_pos.y) return g;
 				}
 			}
 		}
 	}
-	return false;
+	return nullptr;
 }
 
 /**
@@ -1472,6 +1475,7 @@ AnimateResult Person::InteractWithPathObject(PathObjectInstance *obj)
  */
 AnimateResult Person::OnAnimate(int delay)
 {
+	this->queuing_blocked_on = nullptr;
 	this->frame_time -= delay;
 	if (this->frame_time > 0) return OAR_OK;
 
@@ -1498,10 +1502,15 @@ AnimateResult Person::OnAnimate(int delay)
 	}
 
 	const AnimationFrame *frame = &this->frames[this->frame_index];
-	if (this->IsQueuingGuest() && this->IsQueuingGuestNearby(this->vox_pos, this->pix_pos, true)) {
-		/* Freeze in place if we are too close to the person queuing in front of us. */
-		this->frame_time += delay;
-		return OAR_OK;
+	if (this->IsQueuingGuest()) {
+		this->queuing_blocked_on = this->GetQueuingGuestNearby(this->vox_pos, this->pix_pos, true);
+		if (this->queuing_blocked_on != nullptr && this->queuing_blocked_on->queuing_blocked_on != this) {
+			/* Freeze in place if we are too close to the person queuing in front of us. */
+			this->frame_time += delay;
+			return OAR_OK;
+		}
+		/* Either there is no one in front of this person, or each person is waiting for the other one to make the first move. */
+		this->queuing_blocked_on = nullptr;
 	}
 	this->pix_pos.x += frame->dx;
 	this->pix_pos.y += frame->dy;
@@ -1763,12 +1772,11 @@ Guest::~Guest()
 /** Initialize this guest's ride preferences with random values. */
 void Guest::InitRidePreferences()
 {
-	Random r;
-	this->preferred_ride_intensity = r.Uniform(800) + 10;
-	this->min_ride_intensity       = r.Uniform(this->preferred_ride_intensity - 5);
-	this->max_ride_intensity       = r.Uniform(this->min_ride_intensity) + this->preferred_ride_intensity + 5;
-	this->max_ride_nausea          = r.Uniform(this->max_ride_intensity) + this->min_ride_intensity;
-	this->min_ride_excitement      = r.Uniform(this->preferred_ride_intensity);
+	this->preferred_ride_intensity = this->rnd.Uniform(800) + 10;
+	this->min_ride_intensity       = this->rnd.Uniform(this->preferred_ride_intensity - 5);
+	this->max_ride_intensity       = this->rnd.Uniform(this->min_ride_intensity) + this->preferred_ride_intensity + 5;
+	this->max_ride_nausea          = this->rnd.Uniform(this->max_ride_intensity) + this->min_ride_intensity;
+	this->min_ride_excitement      = this->rnd.Uniform(this->preferred_ride_intensity);
 }
 
 void Guest::Activate(const Point16 &start, PersonType person_type)

--- a/src/person.h
+++ b/src/person.h
@@ -130,7 +130,7 @@ public:
 	}
 
 	bool IsQueuingGuest() const;
-	bool IsQueuingGuestNearby(const XYZPoint16& vox_pos, const XYZPoint16& pix_pos, bool only_in_front);
+	const Person *GetQueuingGuestNearby(const XYZPoint16& vox_pos, const XYZPoint16& pix_pos, bool only_in_front);
 
 	void SetName(const std::string &name);
 	std::string GetName() const;
@@ -152,6 +152,7 @@ protected:
 	Random rnd; ///< Random number generator for deciding how the person reacts.
 	std::string name; ///< Name of the person. \c "" means it has a default name (like "Guest XYZ").
 	StringID status;  ///< What the person is doing right now, for display in the GUI.
+	const Person *queuing_blocked_on;  ///< The person standing before this one in the queue, if this is a queuing guest.
 
 	TileEdge GetCurrentEdge() const;
 	uint8 GetInparkDirections();

--- a/src/person.h
+++ b/src/person.h
@@ -170,6 +170,7 @@ protected:
 	virtual bool IsLeavingPath() const;
 	void UpdateZPosition();
 	void SetStatus(StringID s);
+	bool HasCyclicQueuingDependency() const;
 };
 
 /** Activities of the guest. */


### PR DESCRIPTION
Guests don't always walk exactly at the center of a queue path, so at corners there are occasionally two guests who both think the other one is queuing in front of them, deadlocking each other. This branch fixes the bug by letting each guest remember which person they're queuing behind and allowing a guest who detects a cyclic dependency to push in front to break the deadlock.