### PR TITLE
Don't mark ~/OFF as persistent in the Flatpak manifest

### DIFF
--- a/packaging_data/net.freerct.FreeRCT.Devel.json
+++ b/packaging_data/net.freerct.FreeRCT.Devel.json
@@ -5,7 +5,6 @@
 	"sdk": "org.freedesktop.Sdk",
 	"finish-args": [
 		"--device=dri",
-		"--persist=OFF",
 		"--share=ipc",
 		"--socket=wayland",
 		"--socket=fallback-x11"


### PR DESCRIPTION
This was just necessary to work around that FreeRCT did not
implement the XDG Base Directory Specification. The reason it was
set to OFF was due to a bug in FreeRCT's CMake build code. Both of
these things have since been fixed, so let's drop this.