### PR TITLE
Staff wage cuts

### DIFF
--- a/src/person.cpp
+++ b/src/person.cpp
@@ -31,10 +31,10 @@ static const int QUEUE_DISTANCE = 64;  // The pixel distance between two guests 
 assert_compile(256 % QUEUE_DISTANCE == 0);
 
 const std::map<PersonType, Money> StaffMember::SALARY = {
-	{PERSON_MECHANIC,    Money(2700)},  ///< Daily salary of a mechanic.
-	{PERSON_HANDYMAN,    Money(1500)},  ///< Daily salary of a handyman.
-	{PERSON_GUARD,       Money(2000)},  ///< Daily salary of a guard.
-	{PERSON_ENTERTAINER, Money(2000)},  ///< Daily salary of a entertainer.
+	{PERSON_MECHANIC,    Money(270)},  ///< Daily salary of a mechanic.
+	{PERSON_HANDYMAN,    Money(150)},  ///< Daily salary of a handyman.
+	{PERSON_GUARD,       Money(200)},  ///< Daily salary of a guard.
+	{PERSON_ENTERTAINER, Money(200)},  ///< Daily salary of a entertainer.
 };
 
 /**


### PR DESCRIPTION
With the current balancing settings it is practically impossible to run your park efficiently for any extended time. The main reason are the staff wages. In RCT1 a staff member earns around 50$ a month which is a ridiculous amount, but since you can't truly play with more realistic wages this PR reduces salaries by 90% allowing you to actually turn a profit now.