### PR TITLE
Add the 0.1 release to the metainfo

### DIFF
--- a/packaging_data/freerct.metainfo.xml.in
+++ b/packaging_data/freerct.metainfo.xml.in
@@ -25,6 +25,13 @@
 			<image>https://freerct.net/img/screenshots/appdata/mainmenu.png</image>
 		</screenshot>
 	</screenshots>
+	<releases>
+		<release version="0.1" date="2022-03-19">
+			<description>
+				<p>This is the first-ever release of FreeRCT!</p>
+			</description>
+		</release>
+	</releases>
 	<url type="homepage">https://freerct.net</url>
 	<url type="bugtracker">https://github.com/FreeRCT/FreeRCT/issues</url>
 	<project_license>GPL-2.0</project_license>


### PR DESCRIPTION
Needs to be here before we make the tag/branch.