### PR TITLE
Static Windows Builds

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -239,11 +239,13 @@ jobs:
     - name: Prepare vcpkg
       shell: bash
       run: |
-        vcpkg install --triplet=${{ matrix.arch }}-windows \
+        vcpkg install --triplet=${{ matrix.arch }}-windows-static \
           libpng \
           sdl2 \
           sdl2-ttf \
           zlib \
+          graphite2 \
+          harfbuzz \
           # EOF
 
     - name: Install MSVC problem matcher
@@ -264,7 +266,7 @@ jobs:
         if [ ${{ matrix.config }} == Release ]; then rel="-DRELEASE=ON"; else rel=""; fi
         cmake .. \
           -GNinja \
-          -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows \
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-windows-static \
           -DCMAKE_TOOLCHAIN_FILE="c:\vcpkg\scripts\buildsystems\vcpkg.cmake" \
           $rel \
           # EOF

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,9 @@ IF(SDL2_TTF_FOUND)
 	target_link_libraries(freerct ${SDL2TTF_LIBRARY})
 ENDIF()
 
+find_package(PNG REQUIRED)
+target_link_libraries(freerct PNG::PNG)
+
 # Determine version string
 if (NOT DEFINED VERSION_STRING)
 	find_package(Git)
@@ -192,6 +195,21 @@ IF(MSVC)
 	ENDIF()
 
 	add_c_cpp_flags(/W3)
+
+	# Enable static linking.
+	add_definitions(-DWIN32_LEAN_AND_MEAN -D__STDC_FORMAT_MACROS -DNOMINMAX)
+	target_link_libraries(freerct
+		version imm32 winmm
+		freetype harfbuzz graphite2 brotlidec-static brotlicommon-static brotlienc-static
+		ole32 imm32 winmm gdi32 user32 oleaut32 setupapi shell32 advapi32 dinput8 uuid bz2 zlib
+	)
+	IF(RELEASE)
+		string(REPLACE "/MD" "" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
+		add_c_cpp_flags("/MT /EHsc")
+	ELSE()
+		string(REPLACE "/MDd" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+		add_c_cpp_flags("/MTd /EHsc")
+	ENDIF()
 ELSE()
 	IF(RELEASE)
 		# O3 is prone to generating broken code on some compilers, O2 is safer.


### PR DESCRIPTION
Re #254 

This changes the Windows builds to use static linking. I don't understand what these changes actually do, this is hacked together from other projects and web searches for error messages :D

I tested it with Wine and it runs. It still needs explicitly setting the installation dir with `-i` because the hardcoded install dir is different from the install wizard's default install path – keeping the issue open until this is addressed separately.

The only non-windows change here is that we now require libpng as a dependency… which was implicitly required before anyway, just not explicitly checked for and linked.