### PR TITLE
Startup fixes for clean installations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Building the program
 
 Currently only Linux is officially supported, although Windows and MacOS *should* work. Let us know if it's broken.
 
-Almost everything is written in C++, which means you need *g++* or *clang++* to compile it. FreeRCT uses C++11 features, so g++ 4.8+ or clang 3.3+ is recommended.
+Almost everything is written in C++, which means you need *g++* or *clang++* to compile it. FreeRCT uses C++17 features, so g++ 7+ or clang 6+ is recommended.
 In addition, you need:
 
 * *lex/flex* - Scanner generator for generating RCD input files. (optional)
@@ -126,8 +126,7 @@ Now run the program
 
 .. code-block:: bash
 
-        $ cd bin
-        $ ./freerct
+        $ ./bin/freerct
 
 or
 
@@ -138,6 +137,10 @@ or
 which should open a window containing the main menu (see also the pictures in the blog).
 
 Pressing 'q' quits the program.
+
+Use ``--help`` or ``-h`` to view available command-line options.
+
+A detailed manual for the game is available `online <https://freerct.net/manual>`_.
 
 Building Troubleshoot
 ---------------------

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -266,9 +266,8 @@ void MakeDirectory(std::string path)
 	if (path.empty() || PathIsDirectory(path.c_str())) return;
 
 	/* Strip trailing path separators. */
-	const size_t dir_sep_len = strlen(DIR_SEP);
-	while (path.size() >= dir_sep_len && path.compare(path.size() - dir_sep_len, dir_sep_len, DIR_SEP) == 0) {
-		for (size_t i = 0; i < dir_sep_len; ++i) {
+	while (StrEndsWith(path.c_str(), DIR_SEP, false)) {
+		for (size_t i = strlen(DIR_SEP); i > 0; --i) {
 			path.pop_back();
 		}
 	}
@@ -346,7 +345,7 @@ const std::string &GetUserHomeDirectory()
  */
 std::string FindDataFile(const std::string &name)
 {
-	for (std::string path : {std::string(".."), freerct_install_prefix()}) {
+	for (std::string path : {std::string("."), std::string(".."), std::string("..") + DIR_SEP + "..", freerct_install_prefix()}) {
 		path += DIR_SEP;
 		path += name;
 		if (PathIsFile(path.c_str())) return path;

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -261,10 +261,19 @@ bool RcdFileReader::GetBlob(void *address, size_t length)
  * @param path Path of the directory.
  * @todo At the time of writing (2021-06-30) this is tested only on Linux. Before using it anywhere else, test this on all platforms (especially Windows).
  */
-void MakeDirectory(const std::string &path)
+void MakeDirectory(std::string path)
 {
-	if (PathIsDirectory(path.c_str())) return;
+	if (path.empty() || PathIsDirectory(path.c_str())) return;
 
+	/* Strip trailing path separators. */
+	const size_t dir_sep_len = strlen(DIR_SEP);
+	while (path.size() >= dir_sep_len && path.compare(path.size() - dir_sep_len, dir_sep_len, DIR_SEP) == 0) {
+		for (size_t i = 0; i < dir_sep_len; ++i) {
+			path.pop_back();
+		}
+	}
+
+	/* Recursively create parent directories. */
 	const size_t sep_pos = path.rfind(DIR_SEP);
 	if (sep_pos != std::string::npos) MakeDirectory(path.substr(0, sep_pos));
 

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -78,7 +78,7 @@ bool PathIsDirectory(const char *path);
 
 DirectoryReader *MakeDirectoryReader();
 
-void MakeDirectory(const std::string &path);
+void MakeDirectory(std::string path);
 void CopyBinaryFile(const char *src, const char *dest);
 
 const std::string &GetUserHomeDirectory();

--- a/src/rcdfile.h
+++ b/src/rcdfile.h
@@ -30,6 +30,7 @@ public:
 	RcdFileCollection();
 
 	void ScanDirectories();
+	void ScanDirectory(const char *dir, int recursion_depth);
 	void AddFile(const RcdFileInfo &rcd);
 
 	std::map<std::string, RcdFileInfo> rcdfiles; ///< Found unique RCD files, mapping of uri to the Rcd file information.


### PR DESCRIPTION
Fixes #267

One commit to go a few levels up and/or down when scanning for RCD and data files (limited to a few levels to avoid unnecessary in-depth searching), and one commit for the directory creation issue. 

Tested with a nonexistent custom user data dir with and without trailing slash, and running from the top-level dir and from `build` and `build/bin`.