### PR TITLE
Formatting Enhancements

### DIFF
--- a/graphics/rcd/lang/de_DE.yml
+++ b/graphics/rcd/lang/de_DE.yml
@@ -43,6 +43,7 @@ strings:
 
 		NUMBERED_INSTANCE_NAME: "%1% #%2%"
 		RESOLUTION:             "%1%×%2%"
+		GUEST_NAME:             "Besucher %1%"
 
 		DECREASE_BUTTON:          "-"
 		INCREASE_BUTTON:          "+"

--- a/graphics/rcd/lang/de_DE.yml
+++ b/graphics/rcd/lang/de_DE.yml
@@ -18,6 +18,7 @@ strings:
 		NOT_AVAILABLE: "k.A."
 
 		DATETIME_FORMAT: "%d.%m.%Y, %H:%M:%S"
+		DATE_FORMAT:     "%1%. %2%, Jahr %3%"
 		MONTH_JANUARY:   "Januar"
 		MONTH_FEBRUARY:  "Februar"
 		MONTH_MARCH:     "März"

--- a/graphics/rcd/lang/en_GB.yml
+++ b/graphics/rcd/lang/en_GB.yml
@@ -17,6 +17,7 @@ strings:
 		NOT_AVAILABLE: "n/a"
 
 		DATETIME_FORMAT: "%Y-%m-%d, %I:%M:%S %p"
+		DATE_FORMAT:     "%2% %1%, Year %3%"
 		MONTH_JANUARY:   "January"
 		MONTH_FEBRUARY:  "February"
 		MONTH_MARCH:     "March"

--- a/graphics/rcd/lang/en_GB.yml
+++ b/graphics/rcd/lang/en_GB.yml
@@ -42,6 +42,7 @@ strings:
 
 		NUMBERED_INSTANCE_NAME: "%1% #%2%"
 		RESOLUTION:             "%1%x%2%"
+		GUEST_NAME:             "Guest %1%"
 
 		DECREASE_BUTTON:          "-"
 		INCREASE_BUTTON:          "+"

--- a/graphics/rcd/lang/nds_DE.yml
+++ b/graphics/rcd/lang/nds_DE.yml
@@ -43,6 +43,7 @@ strings:
 
 		NUMBERED_INSTANCE_NAME: "%1% #%2%"
 		RESOLUTION:             "%1%×%2%"
+		GUEST_NAME:             "Gast %1%"
 
 		DECREASE_BUTTON:          "-"
 		INCREASE_BUTTON:          "+"

--- a/graphics/rcd/lang/nds_DE.yml
+++ b/graphics/rcd/lang/nds_DE.yml
@@ -18,6 +18,7 @@ strings:
 		NOT_AVAILABLE: "k.A."
 
 		DATETIME_FORMAT: "%d.%m.%Y, %H:%M:%S"
+		DATE_FORMAT:     "%1%. %2%, Jahr %3%"
 		MONTH_JANUARY:   "Januar"
 		MONTH_FEBRUARY:  "Februar"
 		MONTH_MARCH:     "Määrt"

--- a/src/coaster_gui.cpp
+++ b/src/coaster_gui.cpp
@@ -233,7 +233,6 @@ public:
 
 private:
 	CoasterInstance *ci;             ///< Roller coaster instance to display and control.
-	mutable char text_buffer[1024];  ///< Buffer for custom strings.
 
 	void ChooseEntranceExitClicked(bool entrance);
 	RideMouseMode entrance_exit_placement;
@@ -401,9 +400,7 @@ void CoasterInstanceWindow::SetWidgetStringParameters(WidgetNumber wid_num) cons
 			if (this->ci->broken) {
 				_str_params.SetStrID(1, GUI_RIDE_MANAGER_BROKEN_DOWN);
 			} else {
-				snprintf(text_buffer, lengthof(text_buffer), _language.GetSgText(GUI_RIDE_MANAGER_RELIABILITY).c_str(),
-						this->ci->reliability / 100.0);
-				_str_params.SetText(1, text_buffer);
+				_str_params.SetText(1, Format(GUI_RIDE_MANAGER_RELIABILITY, this->ci->reliability / 100.0));
 			}
 			break;
 

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -278,12 +278,11 @@ void MakeDirectory(std::string path)
 
 #ifdef _WIN32
 	if (CreateDirectory(path.c_str(), NULL)) return;
-	fprintf(stderr, "Failed creating directory '%s'\n", path.c_str());
+	error("Failed creating directory '%s'\n", path.c_str());
 #else
 	if (mkdir(path.c_str(), 0x1FF) == 0) return;
-	fprintf(stderr, "Failed creating directory '%s' (%s)\n", path.c_str(), strerror(errno));
+	error("Failed creating directory '%s' (%s)\n", path.c_str(), strerror(errno));
 #endif
-	exit(1);
 }
 
 /**
@@ -296,15 +295,13 @@ void CopyBinaryFile(const char *src, const char *dest)
 	FILE *in_file = nullptr;
 	in_file = fopen(src, "rb");
 	if (in_file == nullptr) {
-		fprintf(stderr, "Could not open file for reading: %s\n", src);
-		exit(1);
+		error("Could not open file for reading: %s\n", src);
 	}
 
 	FILE *out_file = nullptr;
 	out_file = fopen(dest, "wb");
 	if (out_file == nullptr) {
-		fprintf(stderr, "Could not open file for writing: %s\n", dest);
-		exit(1);
+		error("Could not open file for writing: %s\n", dest);
 	}
 
 	for (;;) {
@@ -334,8 +331,7 @@ const std::string &GetUserHomeDirectory()
 		}
 	}
 
-	fprintf(stderr, "Unable to locate the user home directory. Set the HOME environment variable to fix the problem.\n");
-	exit(1);
+	error("Unable to locate the user home directory. Set the HOME environment variable to fix the problem.\n");
 }
 
 /**
@@ -350,8 +346,7 @@ std::string FindDataFile(const std::string &name)
 		path += name;
 		if (PathIsFile(path.c_str())) return path;
 	}
-	fprintf(stderr, "Data file %s is missing, the installation seems to be broken!\n", name.c_str());
-	exit(1);
+	error("Data file %s is missing, the installation seems to be broken!\n", name.c_str());
 }
 
 /**

--- a/src/finances_gui.cpp
+++ b/src/finances_gui.cpp
@@ -145,12 +145,9 @@ void FinancesGui::SetWidgetStringParameters(WidgetNumber wid_num) const
 		case FIN_CASH:         _str_params.SetMoney(1, _finances_manager.GetCash()); break;
 		case FIN_CURRENT_LOAN: _str_params.SetMoney(1, _finances_manager.GetLoan()); break;
 		case FIN_MAX_LOAN:     _str_params.SetMoney(1, _scenario.max_loan         ); break;
-		case FIN_INTEREST: {
-			static char buffer[512];
-			snprintf(buffer, lengthof(buffer), _language.GetSgText(GUI_FINANCES_LOAN_INTEREST_VALUE).c_str(), _scenario.interest * 0.1f);
-			_str_params.SetText(1, buffer);
+		case FIN_INTEREST:
+			_str_params.SetText(1, Format(GUI_FINANCES_LOAN_INTEREST_VALUE, _scenario.interest * 0.1f));
 			break;
-		}
 
 		default: break;
 	}

--- a/src/gentle_thrill_ride_gui.cpp
+++ b/src/gentle_thrill_ride_gui.cpp
@@ -205,7 +205,6 @@ public:
 
 private:
 	GentleThrillRideInstance *ride;  ///< Gentle/Thrill ride instance getting managed by this window.
-	mutable char text_buffer[1024];  ///< Buffer for custom strings.
 
 	void UpdateButtons();
 	void UpdateRecolourButtons();
@@ -308,9 +307,7 @@ void GentleThrillRideManagerWindow::SetWidgetStringParameters(WidgetNumber wid_n
 			if (this->ride->broken) {
 				_str_params.SetStrID(1, GUI_RIDE_MANAGER_BROKEN_DOWN);
 			} else {
-				snprintf(text_buffer, lengthof(text_buffer), _language.GetSgText(GUI_RIDE_MANAGER_RELIABILITY).c_str(),
-						this->ride->reliability / 100.0);
-				_str_params.SetText(1, text_buffer);
+				_str_params.SetText(1, Format(GUI_RIDE_MANAGER_RELIABILITY, this->ride->reliability / 100.0));
 			}
 			break;
 

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -447,12 +447,10 @@ static void MoneyStrFmt(char *dest, size_t size, double amt)
  * @param temp Temperature in 1/10 degrees Celcius to convert.
  * @return Formatted text.
  */
-static std::string TemperatureStrFormat(int temp)
+static inline std::string TemperatureStrFormat(int temp)
 {
-	temp = ((temp < 0) ? temp - 5 : temp + 5) / 10; // Round to degrees Celcius.
-	static char buffer[64];
-	snprintf(buffer, lengthof(buffer), "%d \u2103", temp);  // " " + degrees Celcius, U+2103
-	return buffer;
+	temp = ((temp < 0) ? temp - 5 : temp + 5) / 10;  // Round to degrees Celsius.
+	return Format("%d \u2103", temp);
 }
 
 /**

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -254,8 +254,7 @@ uint16 LanguageManager::RegisterStrings(const TextData &td, const char * const n
 		base = this->free_index;
 		this->free_index += td.string_count;
 		if (this->free_index >= STR_END_FREE_SPACE) {
-			fprintf(stderr, "Not enough space to store strings.\n");
-			exit(1);
+			error("Not enough space to store strings.\n");
 		}
 	} else {
 		assert(base + td.string_count < this->free_index);
@@ -369,14 +368,12 @@ void LanguageBundle::InitMetaInfo(int index)
 	for (uint32 i = 0; i < nrstrings; ++i) {
 		int size = this->values.at(i).size();
 		if (_language.GetStringName(i) == nullptr && size != 0) {
-			fprintf(stderr, "Language %s has a string at undefined index %u.\n",
+			error("Language %s has a string at undefined index %u.\n",
 					this->metadata->name, i);
-			exit(1);
 		}
 		if (size > 1 && size != this->metadata->nplurals) {
-			fprintf(stderr, "Language %s has %d plurals, but string '%s' has %d.\n",
+			error("Language %s has %d plurals, but string '%s' has %d.\n",
 					this->metadata->name, this->metadata->nplurals, _language.GetStringName(i), size);
-			exit(1);
 		}
 	}
 }

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -499,8 +499,7 @@ std::string DrawText(StringID strid, StringParameters *params)
 					break;
 
 				case SPT_NUMBER:
-					snprintf(textbuf, lengthof(textbuf), "%lld", params->parms[n - 1].u.number);
-					buffer += textbuf;
+					buffer += std::to_string(params->parms[n - 1].u.number);
 					break;
 
 				case SPT_MONEY:
@@ -568,16 +567,16 @@ void GetTextSize(StringID strid, int *width, int *height)
 /**
  * Convert the date to a Unicode string.
  * @param d %Date to format.
- * @param format C-Style format code.
  * @return The formatted string.
  * @todo Allow variable number of format parameters, e.g. "mm-yy".
  */
-std::string GetDateString(const Date &d, const char *format)
+std::string GetDateString(const Date &d)
 {
-	static char textbuf[64];
-	const std::string &month = _language.GetSgText(GetMonthName(d.month));
-	snprintf(textbuf, lengthof(textbuf), format, d.day, month.c_str(), d.year);
-	return textbuf;
+	static StringParameters p;
+	p.SetNumber(1, d.day);
+	p.SetStrID(2, GetMonthName(d.month));
+	p.SetNumber(3, d.year);
+	return DrawText(GUI_DATE_FORMAT, &p);
 }
 
 /**

--- a/src/language.h
+++ b/src/language.h
@@ -172,7 +172,7 @@ extern StringParameters _str_params;
 
 std::string DrawText(StringID num, StringParameters *params = &_str_params);
 
-std::string GetDateString(const Date &d, const char *format = "%02d-%s-%02d");
+std::string GetDateString(const Date &d);
 Point32 GetMaxDateSize();
 Point32 GetMoneyStringSize(const Money &amount);
 

--- a/src/language.h
+++ b/src/language.h
@@ -176,4 +176,32 @@ std::string GetDateString(const Date &d, const char *format = "%02d-%s-%02d");
 Point32 GetMaxDateSize();
 Point32 GetMoneyStringSize(const Money &amount);
 
+/**
+ * Convenience wrapper around the snprintf function.
+ * @param format Format string with printf-style placeholders.
+ * @param args Formatting arguments.
+ * @return Formatted text.
+ * @note When possible, use #DrawText instead.
+ */
+template<typename... Args>
+std::string Format(const std::string &format, Args... args)
+{
+	static char buffer[2048];
+	snprintf(buffer, lengthof(buffer), format.c_str(), args...);
+	return buffer;
+}
+
+/**
+ * Convenience wrapper around the snprintf function.
+ * @param format #StringID of the translatable string with printf-style placeholders.
+ * @param args Formatting arguments.
+ * @return Formatted text.
+ * @note When possible, use #DrawText instead.
+ */
+template<typename... Args>
+std::string Format(StringID format, Args... args)
+{
+	return Format(_language.GetSgText(format), args...);
+}
+
 #endif

--- a/src/loadsave.cpp
+++ b/src/loadsave.cpp
@@ -445,11 +445,10 @@ bool LoadGameFile(const char *fname)
 			return false;
 		}
 
-		printf("FATAL ERROR: The reset loader failed to default-initialize the game!\n");
-		printf("This should not happen. Please consider submitting a bug report.\n");
-		printf("Error message: %s\n", e.what());
-		printf("FreeRCT will terminate now.\n");
-		::exit(1);
+		error("FATAL ERROR: The reset loader failed to default-initialize the game!\n"
+				"This should not happen. Please consider submitting a bug report.\n"
+				"Error message: %s\n"
+				"FreeRCT will terminate now.\n", e.what());
 	}
 }
 

--- a/src/people.cpp
+++ b/src/people.cpp
@@ -470,9 +470,7 @@ void Staff::RequestMechanic(RideInstance *ride)
  */
 static void NameNewStaff(StaffMember *m, StringID text)
 {
-	static char buffer[1024];
-	snprintf(buffer, lengthof(buffer), _language.GetSgText(text).c_str(), STAFF_BASE_ID - m->id);
-	m->SetName(buffer);
+	m->SetName(Format(text, STAFF_BASE_ID - m->id));
 }
 
 /**

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -137,7 +137,7 @@ std::string Person::GetName() const
 {
 	if (!this->name.empty()) return this->name;
 
-	StringParameters p;
+	static StringParameters p;
 	p.SetNumber(1, this->id);
 	return DrawText(GUI_GUEST_NAME, &p);
 }
@@ -2406,9 +2406,7 @@ std::string Person::GetStatus() const
 	const std::string text = _language.GetSgText(this->status);
 	if (this->ride == nullptr) return text;
 
-	static char text_buffer[1024];
-	snprintf(text_buffer, lengthof(text_buffer), text.c_str(), this->ride->name.c_str());
-	return text_buffer;
+	return Format(text, this->ride->name.c_str());
 }
 
 /**

--- a/src/person.cpp
+++ b/src/person.cpp
@@ -137,9 +137,9 @@ std::string Person::GetName() const
 {
 	if (!this->name.empty()) return this->name;
 
-	static char buffer[16];
-	sprintf(buffer, "Guest %u", this->id);  // \todo Use a translatable string for this.
-	return buffer;
+	StringParameters p;
+	p.SetNumber(1, this->id);
+	return DrawText(GUI_GUEST_NAME, &p);
 }
 
 /** Recompute the height of the person. */

--- a/src/rcdgen/string_names.h
+++ b/src/rcdgen/string_names.h
@@ -18,6 +18,7 @@ static const char *_gui_string_names[] = {
 	"NOT_AVAILABLE",
 
 	"DATETIME_FORMAT",
+	"DATE_FORMAT",
 	"MONTH_JANUARY",
 	"MONTH_FEBRUARY",
 	"MONTH_MARCH",

--- a/src/rcdgen/string_names.h
+++ b/src/rcdgen/string_names.h
@@ -41,6 +41,7 @@ static const char *_gui_string_names[] = {
 
 	"NUMBERED_INSTANCE_NAME",
 	"RESOLUTION",
+	"GUEST_NAME",
 
 	"INCREASE_BUTTON",
 	"DECREASE_BUTTON",

--- a/src/ride_type.cpp
+++ b/src/ride_type.cpp
@@ -197,7 +197,6 @@ void SetRideRatingStringParam(const uint32 rating)
 		return;
 	}
 
-	static char _text_buffer[1024];
 	std::string str;
 
 	if (rating < 100) {
@@ -214,8 +213,7 @@ void SetRideRatingStringParam(const uint32 rating)
 		str = _language.GetSgText(GUI_RIDE_MANAGER_RATING_EXTREME);
 	}
 
-	snprintf(_text_buffer, lengthof(_text_buffer), str.c_str(), rating / 100.0);
-	_str_params.SetText(1, _text_buffer);
+	_str_params.SetText(1, Format(str, rating / 100.0));
 }
 
 /**

--- a/src/sprite_data.cpp
+++ b/src/sprite_data.cpp
@@ -254,8 +254,7 @@ uint32 ImageData::GetPixel(uint16 xoffset, uint16 yoffset, const Recolouring *re
 ImageData *LoadImage(RcdFileReader *rcd_file)
 {
 	if (_sprites_loaded >= MAX_IMAGE_COUNT) {
-		fprintf(stderr, "Attempt to load too many sprites! MAX_IMAGE_COUNT needs to be increased.\n");
-		exit(1);
+		error("Attempt to load too many sprites! MAX_IMAGE_COUNT needs to be increased.\n");
 	}
 	bool is_8bpp = strcmp(rcd_file->name, "8PXL") == 0;
 	if (rcd_file->version != (is_8bpp ? 2 : 1)) return nullptr;

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -578,11 +578,10 @@ bool VideoSystem::MainLoopDoCycle()
 	}
 
 	if (this->missing_sprites) {
-		printf("FATAL ERROR: FreeRCT is missing some sprites.\n");
-		printf("This should not happen. You are most likely using corrupt or incompatible RCD files.\n");
-		printf("Please ensure that your RCD files can be read by this version of FreeRCT.\n");
-		printf("The program will terminate now.\n");
-		exit(1);
+		error("FATAL ERROR: FreeRCT is missing some sprites.\n"
+				"This should not happen. You are most likely using corrupt or incompatible RCD files.\n"
+				"Please ensure that your RCD files can be read by this version of FreeRCT.\n"
+				"The program will terminate now.\n");
 	}
 
 	return true;


### PR DESCRIPTION
Several commits to make formatting functions nicer:
- Localizable date format and guest name.
- Simplified money format function.
- Wrap `s(n)printf` calls in a single `Format()` function, and use `DrawText` instead where applicable.
- Use `error()` instead of `fprintf`+`exit` for error conditions.