### PR TITLE
First round of OpenGL-related bugfixes

### DIFF
--- a/data/shaders/colour.fp
+++ b/data/shaders/colour.fp
@@ -1,4 +1,5 @@
-#version 330 core
+#version 300 es
+precision mediump float;
 
 out vec4 f_col;
 in vec4 v_col;

--- a/data/shaders/colour.vp
+++ b/data/shaders/colour.vp
@@ -1,4 +1,4 @@
-#version 330 core
+#version 300 es
 
 layout (location = 0) in vec2 a_position;
 layout (location = 1) in vec4 a_rgba;

--- a/data/shaders/image.fp
+++ b/data/shaders/image.fp
@@ -1,4 +1,6 @@
-#version 330 core
+#version 300 es
+precision mediump float;
+
 out vec4 frag_colour;
 
 in vec4 v_overlay;

--- a/data/shaders/image.vp
+++ b/data/shaders/image.vp
@@ -1,4 +1,5 @@
-#version 330 core
+#version 300 es
+
 layout (location = 0) in vec3 a_pos;
 layout (location = 1) in vec4 a_colour;
 layout (location = 2) in vec2 a_texel;

--- a/data/shaders/text.fp
+++ b/data/shaders/text.fp
@@ -1,4 +1,6 @@
-#version 330 core
+#version 300 es
+precision mediump float;
+
 in vec2 tex_coords;
 out vec4 colour;
 

--- a/data/shaders/text.vp
+++ b/data/shaders/text.vp
@@ -1,4 +1,5 @@
-#version 330 core
+#version 300 es
+
 layout (location = 0) in vec4 vertex;
 out vec2 tex_coords;
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -117,7 +117,7 @@ void TextRenderer::LoadFont(const std::string &font_path, GLuint font_size)
 		glTexImage2D(
 				GL_TEXTURE_2D,
 				0,
-				GL_RED,
+				GL_R8,
 				face->glyph->bitmap.width,
 				face->glyph->bitmap.rows,
 				0,
@@ -304,7 +304,7 @@ EM_JS(int, GetEmscriptenCanvasHeight, (), { return canvas.clientHeight; });
  * @param new_w New width.
  * @param new_h New height.
  */
-void VideoSystem::FramebufferSizeCallback(GLFWwindow *window, int new_w, int new_h)
+void VideoSystem::FramebufferSizeCallback([[maybe_unused]] GLFWwindow *window, int new_w, int new_h)
 {
 	assert(window == _video.window);
 	assert(new_w >= 0);
@@ -326,7 +326,7 @@ void VideoSystem::FramebufferSizeCallback(GLFWwindow *window, int new_w, int new
  * @param action Whether the mouse button was pressed or released.
  * @param mods Bitset of modifier keys.
  */
-void VideoSystem::KeyCallback(GLFWwindow *window, int key, [[maybe_unused]] int scancode, int action, int mods)
+void VideoSystem::KeyCallback([[maybe_unused]] GLFWwindow *window, int key, [[maybe_unused]] int scancode, int action, int mods)
 {
 	assert(window == _video.window);
 	if (action != GLFW_PRESS) return;
@@ -444,7 +444,7 @@ void VideoSystem::KeyCallback(GLFWwindow *window, int key, [[maybe_unused]] int 
  * @param window Window in which the event occurred.
  * @param codepoint The unicode character.
  */
-void VideoSystem::TextCallback(GLFWwindow *window, uint32 codepoint)
+void VideoSystem::TextCallback([[maybe_unused]] GLFWwindow *window, uint32 codepoint)
 {
 	assert(window == _video.window);
 	char buffer[] = {0, 0, 0, 0, 0};
@@ -458,7 +458,7 @@ void VideoSystem::TextCallback(GLFWwindow *window, uint32 codepoint)
  * @param x New mouse position X coordinate.
  * @param y New mouse position Y coordinate.
  */
-void VideoSystem::MouseMoveCallback(GLFWwindow *window, double x, double y)
+void VideoSystem::MouseMoveCallback([[maybe_unused]] GLFWwindow *window, double x, double y)
 {
 	assert(window == _video.window);
 	_video.mouse_x = std::max(0.0, std::min<double>(x, _video.width));
@@ -472,7 +472,7 @@ void VideoSystem::MouseMoveCallback(GLFWwindow *window, double x, double y)
  * @param xdelta Amount by which the wheel was moved in the horizontal direction..
  * @param ydelta Amount by which the wheel was moved in the vertical direction.
  */
-void VideoSystem::ScrollCallback(GLFWwindow *window, [[maybe_unused]] double xdelta, double ydelta)
+void VideoSystem::ScrollCallback([[maybe_unused]] GLFWwindow *window, [[maybe_unused]] double xdelta, double ydelta)
 {
 	assert(window == _video.window);
 	if (abs(ydelta) < 0.01) return;
@@ -486,7 +486,7 @@ void VideoSystem::ScrollCallback(GLFWwindow *window, [[maybe_unused]] double xde
  * @param action Whether the mouse button was pressed or released.
  * @param mods Bitset of modifier keys.
  */
-void VideoSystem::MouseClickCallback(GLFWwindow *window, int button, int action, [[maybe_unused]] int mods) {
+void VideoSystem::MouseClickCallback([[maybe_unused]] GLFWwindow *window, int button, int action, [[maybe_unused]] int mods) {
 	assert(window == _video.window);
 
 	switch (button) {
@@ -561,7 +561,9 @@ void VideoSystem::Initialize(const std::string &font, int font_size)
 
 	this->UpdateClip();
 	glfwSetFramebufferSizeCallback(this->window, FramebufferSizeCallback);
+#ifndef WEBASSEMBLY
 	glfwSetInputMode(this->window, GLFW_STICKY_KEYS, GL_TRUE);
+#endif
 	glfwSetCursorPosCallback(this->window, MouseMoveCallback);
 	glfwSetScrollCallback(this->window, ScrollCallback);
 	glfwSetMouseButtonCallback(this->window, MouseClickCallback);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -966,7 +966,7 @@ void WindowManager::MouseButtonEvent(MouseButtons button, bool pressed)
 
 	if ((_video.GetMouseDragging() & button) != MB_NONE) {
 		if (!pressed) _video.SetMouseDragging(button, false, false);
-	} else if (pressed) {
+	} else if (pressed && this->current_window != nullptr) {
 		WmMouseEvent me = this->current_window->OnMouseButtonEvent(button);
 		switch (me) {
 			case WMME_NONE:


### PR DESCRIPTION
- WASM worked locally but not on the website. This fixes it for the website as well. (Note: The website currently serves this patch.)
  - After this patch, we really use OpenGL *ES* 3.3 with OpenGL ES Shading Language 300.
- Fix a `nullptr` dereference.
- Flag some variables as `maybe_unused` that are used only in asserts.