### PR TITLE
Fade toolbar message previews in slowly

### DIFF
--- a/src/inbox_gui.cpp
+++ b/src/inbox_gui.cpp
@@ -122,8 +122,9 @@ void InboxGui::DrawWidget(const WidgetNumber wid_num, const BaseWidget *wid) con
  * @param msg Message to draw.
  * @param rect Rectangle on the screen.
  * @param narrow Whether to use a condensed layout.
+ * @param obscure_fraction Fraction of the message to obscure (\c 0 to disable).
  */
-void DrawMessage(const Message *msg, const Rectangle32 &rect, const bool narrow)
+void DrawMessage(const Message *msg, const Rectangle32 &rect, const bool narrow, const float obscure_fraction)
 {
 	const int text_w = rect.width - rect.height - 3 * MESSAGE_PADDING;
 	const int text_y = (narrow ? MESSAGE_PADDING : GetTextHeight()) + MESSAGE_PADDING;
@@ -146,6 +147,11 @@ void DrawMessage(const Message *msg, const Rectangle32 &rect, const bool narrow)
 	if (!narrow) {
 		_str_params.SetDate(1, msg->timestamp);
 		DrawString(STR_ARG1, TEXT_WHITE, rect.base.x + MESSAGE_PADDING, rect.base.y, text_w);
+	}
+
+	if (obscure_fraction > 0.f) {
+		int obscure_w = text_w * obscure_fraction;
+		_video.FillRectangle(Rectangle32(rect.base.x + text_w - obscure_w, rect.base.y, obscure_w, rect.height), 0xff);
 	}
 
 	int sprite_to_draw;

--- a/src/toolbar_gui.cpp
+++ b/src/toolbar_gui.cpp
@@ -619,7 +619,9 @@ void BottomToolbarWindow::DrawWidget(WidgetNumber wid_num, const BaseWidget *wid
 
 		case BTB_MESSAGE:
 			if (_inbox.display_message != nullptr) {
-				DrawMessage(_inbox.display_message, Rectangle32(this->GetWidgetScreenX(wid), this->GetWidgetScreenY(wid), wid->pos.width, wid->pos.height), true);
+				constexpr float MESSAGE_FADEIN_TIME = 2000.f;  ///< Time in milliseconds how long a message takes to fully appear in the preview pane.
+				DrawMessage(_inbox.display_message, Rectangle32(this->GetWidgetScreenX(wid), this->GetWidgetScreenY(wid), wid->pos.width, wid->pos.height),
+						true, 1.f - _inbox.display_time / MESSAGE_FADEIN_TIME);
 			}
 			break;
 	}

--- a/src/window.h
+++ b/src/window.h
@@ -398,7 +398,7 @@ void ShowRideBuildGui(FixedRideInstance *instance);
 void ShowSettingGui();
 void ShowInboxGui();
 void ShowMinimap();
-void DrawMessage(const Message *msg, const Rectangle32 &rect, bool narrow);
+void DrawMessage(const Message *msg, const Rectangle32 &rect, bool narrow, float obscure_fraction = 0.f);
 
 static const uint32 DEFAULT_ERROR_MESSAGE_TIMEOUT = 8000;   ///< Number of ticks after which an error message auto-closes by default.
 void ShowErrorMessage(StringID str1, StringID str2, const std::function<void()> &string_params, uint32 timeout = DEFAULT_ERROR_MESSAGE_TIMEOUT);


### PR DESCRIPTION
Uncover new messages in the bottom toolbar slowly from left to right over 2 seconds like in RCT1 to visually alert the player to the arrival of a new message.