### PR TITLE
Redesign path building GUI

### DIFF
--- a/graphics/rcd/gui.fml
+++ b/graphics/rcd/gui.fml
@@ -8,7 +8,7 @@ file("gui.rcd") {
 	INFO {
 		name: "Baseset GUI sprites";
 		uri: "org.freerct/baseset/gui/1";
-		description: "FreeRCT baseset shops.";
+		description: "FreeRCT baseset GUI sprites.";
 	}
 
 	// Build direction arrows.

--- a/src/path_build.h
+++ b/src/path_build.h
@@ -11,12 +11,18 @@
 #define PATH_BUILD_H
 
 bool PathExistsAtBottomEdge(XYZPoint16 voxel_pos, TileEdge edge);
+
 bool BuildUpwardPath(const XYZPoint16 &voxel_pos, TileEdge edge, PathType path_type, PathStatus path_status, bool test_only, bool pay);
 bool BuildFlatPath(const XYZPoint16 &voxel_pos, PathType path_type, PathStatus path_status, bool test_only, bool pay);
 bool BuildDownwardPath(XYZPoint16 voxel_pos, TileEdge edge, PathType path_type, PathStatus path_status, bool test_only, bool pay);
+
 bool RemovePath(const XYZPoint16 &voxel_pos, bool test_only, bool pay);
 bool ChangePath(const XYZPoint16 &voxel_pos, PathType path_type, PathStatus path_status, bool test_only, bool pay);
+
 uint8 CanBuildPathFromEdge(const XYZPoint16 &voxel_pos, TileEdge edge);
+
 uint8 GetPathAttachPoints(const XYZPoint16 &voxel_pos);
+
+Money PathBuildingCost(const XYZPoint16 &voxel_pos, PathType path_type, PathStatus path_status, uint8 path_spr);
 
 #endif

--- a/src/sprite_store.cpp
+++ b/src/sprite_store.cpp
@@ -1134,8 +1134,8 @@ void GuiSprites::LoadGSLP(RcdFileReader *rcd_file, const ImageMap &sprites, cons
 	for (uint i = 0; i < TPB_COUNT; i++) {
 		LoadSpriteFromFile(rcd_file, sprites, &this->bank_select[i]);
 	}
-	LoadSpriteFromFile(rcd_file, sprites, &this->triangle_left);
 	LoadSpriteFromFile(rcd_file, sprites, &this->triangle_right);
+	LoadSpriteFromFile(rcd_file, sprites, &this->triangle_left);
 	LoadSpriteFromFile(rcd_file, sprites, &this->triangle_up);
 	LoadSpriteFromFile(rcd_file, sprites, &this->triangle_down);
 	for (uint i = 0; i < 2; i++) {


### PR DESCRIPTION
Redesigned the path GUI for ease of use (bigger buttons, arrangement more similar but not identical to RCT1) and added useful information (path and cost preview in directional mode).

![grafik](https://user-images.githubusercontent.com/48293446/226124659-370b538c-debf-4505-9364-c80b01dafc08.png)
