### PR TITLE
Fix Windows linking and install dir detection

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -251,14 +251,13 @@ jobs:
     - name: Prepare vcpkg
       shell: bash
       run: |
-        vcpkg install --triplet=${{ matrix.arch }}-windows-static \
+        vcpkg install --disable-metrics --triplet=${{ matrix.arch }}-windows-static \
           libpng \
           glfw3 \
           glew \
           freetype-gl \
           zlib \
           graphite2 \
-          harfbuzz \
           # EOF
 
     - name: Install MSVC problem matcher

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,7 +202,7 @@ IF(MSVC)
 	add_definitions(-DWIN32_LEAN_AND_MEAN -D__STDC_FORMAT_MACROS -DNOMINMAX)
 	target_link_libraries(freerct
 		version imm32 winmm
-		harfbuzz graphite2 brotlidec-static brotlicommon-static brotlienc-static
+		graphite2 brotlidec-static brotlicommon-static brotlienc-static
 		ole32 imm32 winmm gdi32 user32 oleaut32 setupapi shell32 advapi32 dinput8 uuid
 	)
 	IF(RELEASE)

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -332,7 +332,6 @@ bool RcdFileReader::GetBlob(void *address, size_t length)
 /**
  * Create a directory and all its parent directories if it did not exist yet.
  * @param path Path of the directory.
- * @todo At the time of writing (2021-06-30) this is tested only on Linux. Before using it anywhere else, test this on all platforms (especially Windows).
  */
 void MakeDirectory(const std::string &path)
 {


### PR DESCRIPTION
- Fixes the current failure in the MSVC CI (harfbuzz seems to be not required at all)
- Fix autodetection of the installation directory on Windows (re #269)

The resulting x64 Debug binary was tested in Wine 8.0.1 on Linux where it runs successfully.