### PR TITLE
Move to GL(ES) 1.x and some QoL

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ IF(WEBASSEMBLY)
 	)
 
 	add_flags(CMAKE_EXE_LINKER_FLAGS "${WASM_FLAGS} \
-			-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s EXIT_RUNTIME=1 -s STACK_SIZE=131072 -s USE_GLFW=3 -s FULL_ES3 -s ASSERTIONS=1 -s WASM=1 -s ASYNCIFY \
+			-s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -s USE_WEBGL2=1 -s INITIAL_MEMORY=67108864 -s EXIT_RUNTIME=1 -s STACK_SIZE=18668848 -s USE_GLFW=3 -s GL_UNSAFE_OPTS=0 -s LEGACY_GL_EMULATION=1 -s ASSERTIONS=1 -s WASM=1 -s ASYNCIFY \
 			--preload-file ${CMAKE_INSTALL_PREFIX}")
 
 	FUNCTION(find_package)
@@ -107,7 +107,7 @@ add_dependencies(freerct rcd)
 IF(NOT WEBASSEMBLY)
 	find_package(PNG REQUIRED)
 	find_package(OpenGL REQUIRED)
-	find_package(glfw3 3.3 REQUIRED)
+	#find_package(glfw3 3.3 REQUIRED)
 	find_package(GLEW REQUIRED)
 	find_package(Freetype REQUIRED)
 	include_directories(freerct ${GLEW_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS})
@@ -145,6 +145,13 @@ IF(ASAN)
 		message(FATAL_ERROR "ASan should be used only in debug builds.")
 	ENDIF()
 	add_c_cpp_flags("-fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g")
+ENDIF()
+
+IF(GPERF)
+	if(RELEASE)
+		message(FATAL_ERROR "GPerfTools should only be used in debug builds.")
+	ENDIF()
+	target_link_libraries(freerct profiler)
 ENDIF()
 
 # Compiler flags

--- a/src/coaster.cpp
+++ b/src/coaster.cpp
@@ -824,6 +824,7 @@ void CoasterTrain::OnAnimate(int delay)
 				is_inside_station = true;
 			}
 			if (is_inside_station) {
+				this->speed = 0;
 				this->station_policy = other_train_in_station_front ? TSP_IN_STATION_BACK : TSP_IN_STATION_FRONT;
 			}
 		}

--- a/src/ride_gui.cpp
+++ b/src/ride_gui.cpp
@@ -202,6 +202,13 @@ void RideSelectGui::DrawWidget(WidgetNumber wid_num, const BaseWidget *wid) cons
 			for (uint i = 0; i <= ride_type->designs.size() && lines > 0; ++i) {
 				if (counter >= start) {
 					lines--;
+					if(ride_type->designs.size() < 1) {
+						Point32 img_rect(this->GetWidgetScreenX(wid), this->GetWidgetScreenY(wid));
+						img_rect.x += 256;
+						img_rect.y += 32;
+						_video.BlitImage(img_rect, ride_type->GetView(1));
+					}
+					
 					DrawString(i == ride_type->designs.size() ? _language.GetSgText(i == 0 ? GUI_RIDE_SELECT_NO_DESIGNS : GUI_RIDE_SELECT_CUSTOM_DESIGN) :
 							ride_type->designs.at(i).name, (this->current_design == i) ? TEXT_WHITE : TEXT_BLACK, rect.x, rect.y, wid->pos.width);
 					rect.y += GetTextHeight();

--- a/src/video.h
+++ b/src/video.h
@@ -178,6 +178,7 @@ public:
 	 */
 	inline void DrawRectangle(const Rectangle32 &rect, uint32 col)
 	{
+
 		this->DoDrawLine(rect.base.x, rect.base.y,
 				rect.base.x + static_cast<float>(rect.width), rect.base.y, col);
 		this->DoDrawLine(rect.base.x, rect.base.y,


### PR DESCRIPTION
Hey there!
This is my first time contributing to FreeRCT. I really like the project so far. 
## I have made a few changes:
- First, I added a little preview in the building gui to see what you are going to place.
- Next is the move to GL(ES) 1.0. This might seem a bit weird, but in my opinion GLES1 usually runs better and allows more compatibility. The WASM build does not like some of it for now, maybe GL3 could be enabled at wish. (GL3 seems overkill for a RCT game).
- I added optional GPerfTools to CMakeLists.txt.
- I fixed a bug where the speed of the coaster cart would still be saved, even after the station, so extreme coasters caused the cart to still have acceleration when leaving the station.
- find_package(glfw) seemed to not work, even though GLFW was installed.
## Some things I'd like to add in the future:
- An "easy" python script to create new (simple) rides as a question/answer system (And an additional blender script for rendering rides).
- Fix right mouse button drag when building a ride.
- Add zoom-in/out buttons in the toolbar directly and rotation buttons
- Scaleable toolbar
- A more memory efficient coaster.
- Ports to multiple platforms.
- More realistic park rating system

I'd love to hear some feedback and let me know your thoughts!